### PR TITLE
Update FSI section

### DIFF
--- a/03-modeling/FluidStructure/README.adoc
+++ b/03-modeling/FluidStructure/README.adoc
@@ -31,7 +31,7 @@ stem:[\boldsymbol{(1)}, \boldsymbol{(2)}, \boldsymbol{(3)}] are the fluid-strutu
 
 === Fluid structure coupling conditions with 1D reduced model
 
-For the link:FSIModel.adoc#_fluid_structure_coupling_conditions[coupling conditions], between the 2D fluid and 1D structure, we need to modify the original ones $$ \boldsymbol{(1)},\boldsymbol{(2)}, \boldsymbol{(3)} $$ by
+For the link:FSIModel.adoc#_fluid_structure_coupling_conditions[coupling conditions], between the 2D fluid and 1D structure, we need to modify the original ones stem:[\boldsymbol{(1)},\boldsymbol{(2)}, \boldsymbol{(3)}] by
 
 [stem]
 ++++

--- a/04-learning/FSI/2DElasticTube/README.adoc
+++ b/04-learning/FSI/2DElasticTube/README.adoc
@@ -2,23 +2,21 @@
 :toc:
 :toc-placement: preamble
 :toclevels: 1
-:biblio: ../../Appendix/Bibliography/readme.adoc 
+//:biblio: ../../Appendix/Bibliography/readme.adoc
 
-This test case has originally been realised by
-link:{biblio}#pena09:_high_order_method_in_space[Pena],
-link:{biblio}#nobile2001numerical[Nobile] and
-link:{biblio}#gerbeau2003quasi[GerbeauVidrascu] only with the free outlet
-condition.
+:icons: font
+:stem: latexmath
+:imagesdir: .
 
-Computer codes, used for the acquisition of results, are from Vincent
-link:{biblio}#bloodflowChabannes[Chabannes].
+This test case has originally been realised by <<Pena>>, <<Nobile>> and <<GerbeauVidrascu>> only with the free outlet condition.
+
+Computer codes, used for the acquisition of results, are from Vincent <<Chabannes>>
 
 == Problem Description 
 
 We interest here to the case of bidimensional blood flow modelisation. We want
 to reproduce and observe pressure wave spread into a canal with a
-link:../readme.adoc#_fluid_structure_model[fluid-structure interaction model].
-
+link:../README.adoc[fluid-structure interaction model].
 
 [[img-geometry1]]
 image::ElasticTube.png[caption="Figure 1 : ", title="Geometry of two-dimension elastic tube.", alt="Elastic Tube Geometry", width="600", align="center"]  
@@ -27,70 +25,55 @@ The figure above shows us the initial geometry we will work on. The canal is
 represent by a rectangle with width and height, respectively  equal to 6 and 1
 cm. The upper and lower walls are mobile and so, can be moved by flow action.
 
-By using the link:../../CSM/readme.adoc#_axisymmetric_reduced_model[1D reduced
-model], named generalized string and explained by
-link:{biblio}#bloodflowChabannes[Chabannes], we didn't need to define the
-elastic domain ( for the vascular wall ) here. So the structure domain is
-$$\Omega_s^*=\Gamma_{fsi}^*$$
+By using the link:../../CSM/README.adoc[1D reduced model], named generalized string and explained by <<Chabannes>>, we didn't need to define the
+elastic domain ( for the vascular wall ) here. So the structure domain is stem:[\Omega_s^*=\Gamma_{fsi}^*]
 
 During this benchmark, we will compare two different cases : the free outlet
 condition and the Windkessel model. The first one, as its name said, impose a
 free condition on the fluid at the end of the domain. The second one is used to
 model more realistically an flow outlet into our case. The chosen time step is
-$$\Delta t=0.0001$$
+stem:[\Delta t=0.0001]
 
 === Boundary conditions 
 
 We set :
 
-* on $$\Gamma_f^{i,*}$$ the pressure wave pulse
-
-$$
+* on stem:[\Gamma_f^{i,*}] the pressure wave pulse
+\[
 \boldsymbol{\sigma}_{f} \boldsymbol{n}_f =
-  \left\{
-  \begin{aligned}
-    & \left(-\frac{2 \cdot 10^4}{2} \left( 1 - \cos \left(  \frac{ \pi t} {2.5 \cdot 10^{-3}} \right) \right), 0\right)^T  \quad & \text{ si } t < 0.005 \\
-    & \boldsymbol{0} \quad & \text{ sinon }
-  \end{aligned}
-  \right.
-$$
+\left\{
+\begin{aligned}
+& \left(-\frac{2 \cdot 10^4}{2} \left( 1 - \cos \left(  \frac{ \pi t} {2.5 \cdot 10^{-3}} \right) \right), 0\right)^T  \quad & \text{ if } t < 0.005 \\
+& \boldsymbol{0} \quad & \text{ else }
+\end{aligned}
+\right.
+\]
 
-* on $$\Gamma_f^{o,*}$$
-    - Case 1 : free outlet
-    $$
-    \boldsymbol{\sigma}_{f} \boldsymbol{n}_f =0
-    $$
-    - Case 2 : Windkessel model ( $$P_0$$ proximal pressure, see link:{biblio}#bloodflowChabannes[Chabannes] )
-    $$
-    \boldsymbol{\sigma}_{f} \boldsymbol{n}_f = -P_0\boldsymbol{n}_f
-    $$
+* on stem:[\Gamma_f^{o,*}]
+    ** Case 1 : free outlet : stem:[\boldsymbol{\sigma}_{f} \boldsymbol{n}_f =0]
+    ** Case 2 : Windkessel model ( stem:[P_0] proximal pressure, see <<Chabannes>> ) : stem:[\boldsymbol{\sigma}_{f} \boldsymbol{n}_f = -P_0\boldsymbol{n}_f]
 
-* on $$\Gamma_f^{i,*}$$ U $$\Gamma_f^{o,*}$$ a null displacement
+* on stem:[\Gamma_f^{i,*} \cup \Gamma_f^{o,*}] a null displacement : stem:[\boldsymbol{\eta}_f=0]
 
-$$
-\boldsymbol{\eta}_f=0
-$$
+* on stem:[\Gamma^*_{fsi}] : stem:[\eta_s=0]
 
-* on $$\Gamma^*_{fsi}$$ 
+* We add also the link:../../CSM/README.adoc[specific coupling conditions], obtained from the axisymmetric reduced model, on stem:[\Gamma^*_{fsi}]
 
-$$
-\eta_s=0
-$$
-
-* We add also the link:../../CSM/readme.adoc#_axisymmetric_reduced_model[specific coupling conditions], obtained from the axisymmetric reduced model, on $$\Gamma^*_{fsi}$$ 
-
-$$
+[stem]
+++++
 \dot{\eta}_s \boldsymbol{e}_r - \boldsymbol{u}_f = \boldsymbol{0}
-$$
+++++
 
-$$
+[stem]
+++++
 f_s  + \left(J_{\mathcal{A}_f^t} \boldsymbol{F}_{\mathcal{A}_f^t}^{-T} \hat{\boldsymbol{\sigma}}_f \boldsymbol{n}^*_f\right) \cdot \boldsymbol{e}_r
 =  0
-$$
+++++
 
-$$
+[stem]
+++++
 \boldsymbol{\varphi}_s^t  - \mathcal{A}_f^t = \boldsymbol{0}
-$$
+++++
 
 === Initial conditions
 
@@ -100,46 +83,45 @@ $$
 .Fixed and Variable Input Parameters
 |===
 | Name |Description | Nominal Value | Units
-|$$E_s$$ | Young's modulus | $$0.75 $$  | $$dynes/cm^2$$
-|$$\nu_s$$ | Poisson's ratio | $$0.5$$  |dimensionless
-|$$h$$|walls thickness|0.1|$$cm$$
-|$$\rho_s$$ | structure density | $$1.1$$  |$$g/cm^3$$
-|$$R_0$$|tube radius|$$0.5$$|$$cm$$
-|$$G_s$$| shear modulus |$$10^5$$|$$Pa$$
-|$$k$$|Timoshenko’s correction factor|$$2.5$$|dimensionless
-|$$\gamma_v$$|viscoelasticity parameter|$$0.01$$|dimensionless
-|$$\mu_f$$ |viscosity | $$0.003$$  |$$poise$$ 
-|$$\rho_f$$ | density | $$1$$  | $$g/cm^3$$
-|$$R_p$$ | proximal resistance | $$400$$  | 
-|$$R_d$$ | distal resistance| $$6.2 \times 10^3$$  | 
-|$$C_d$$ | capacitance | $$2.72 \times 10^{-4}$$  |
+|stem:[E_s] | Young's modulus | stem:[0.75]  | stem:[dynes.cm^{-2}]
+|stem:[\nu_s] | Poisson's ratio | stem:[0.5]  |dimensionless
+|stem:[h]|walls thickness|0.1|stem:[cm]
+|stem:[\rho_s] | structure density | stem:[1.1] |stem:[g.cm^{-3}]
+|stem:[R_0]|tube radius|stem:[0.5]|stem:[cm]
+|stem:[G_s]| shear modulus |stem:[10^5]|stem:[Pa]
+|stem:[k]|Timoshenko’s correction factor|stem:[2.5]|dimensionless
+|stem:[\gamma_v]|viscoelasticity parameter|stem:[0.01]|dimensionless
+|stem:[\mu_f] |viscosity | stem:[0.003]  |stem:[poise]
+|stem:[\rho_f] | density | stem:[1]  | stem:[g.cm^{-3}]
+|stem:[R_p] | proximal resistance | stem:[400]  | 
+|stem:[R_d] | distal resistance| stem:[6.2 \times 10^3]  | 
+|stem:[C_d] | capacitance | stem:[2.72 \times 10^{-4}]  |
 |===
 
 == Outputs
 
-After solving the link:../readme.adoc#_fluid_structure_model[fluid struture model], we obtain $$(\mathcal{A}^t, \boldsymbol{u}_f, p_f, \boldsymbol{\eta}_s)$$ 
+After solving the link:../readme.adoc#_fluid_structure_model[fluid struture model], we obtain stem:[(\mathcal{A}^t, \boldsymbol{u}_f, p_f, \boldsymbol{\eta}_s)]
 
-with $$\mathcal{A}^t$$ the ALE map, $$\boldsymbol{u}_f$$ the fluid velocity,
-$$p_f$$ the fluid pressure and $$\boldsymbol\eta_s$$ the structure displacement
-
+with stem:[\mathcal{A}^t] the ALE map, stem:[\boldsymbol{u}_f] the fluid velocity,
+stem:[p_f] the fluid pressure and stem:[\boldsymbol\eta_s] the structure displacement
 
 == Discretization
 
-$$\mathcal{F}$$ is the set of all mesh faces, we denote $$\mathcal{F}_{stab}$$
+stem:[\mathcal{F}] is the set of all mesh faces, we denote stem:[\mathcal{F}_{stab}]
 the face we stabilize 
-$$
+[stem]
+++++
 \mathcal{F}_{stab} = \mathcal{F} \bigcap \left( \left\{ (x,y) \in \mathrm{R}^2:
 (x - 0.3) \leqslant 0 \right\} \cup  \left\{ (x,y) \in \mathrm{^2: (x - 5.7) }
 \geqslant 0   \right\} \right)
-$$
+++++
 
 In fact, after a first attempt, numerical instabilities can be observed at the
 fluid inlet. These instabilities, caused by pressure wave, and especially by
 the Neumann condition, make our fluid-structure solver diverge.
 
 To correct them, we choose to add a stabilization term, obtain from the
-stabilized CIP formulation ( see link:{biblio}#bloodflowChabannes[Chabannes]
-Chapter 6 ).
+stabilized CIP formulation ( see <<Chabannes>>, Chapter 6 ).
 
 As this stabilization bring an important cost with it, by increasing the number
 of non-null term into the problem matrix, we only apply it at the fluid
@@ -151,17 +133,17 @@ Now we present the different situations we worked on.
 [cols="1,1,1,2,2,2,2,2,2"]
 |===
 3.2+|Config 3+|Fluid 3+| Structure
-|$$N_{elt}$$|$$N_{geo}$$|$$N_{dof}$$|$$N_{elt}$$|$$N_{geo}$$|$$N_{dof}$$
-3+|$$(1)$$|$$342$$|$$3$$ $$(P4P3)$$|$$7377$$|$$58$$|$$1$$|$$176$$ $$(P3)$$
-3+|$$(2)$$|$$342$$|$$4$$ $$(P5P4)$$|$$11751$$|$$58$$|$$1$$|$$234$$ $$(P4)$$
+|stem:[N_{elt}]|stem:[N_{geo}]|stem:[N_{dof}]|stem:[N_{elt}]|stem:[N_{geo}]|stem:[N_{dof}]
+3+|stem:[(1)]|stem:[342]|stem:[3~(P4P3)]|stem:[7377]|stem:[58]|stem:[1]|stem:[176~(P3)]
+3+|stem:[(2)]|stem:[342]|stem:[4~(P5P4)]|stem:[11751]|stem:[58]|stem:[1]|stem:[234~(P4)]
 |===
 
-For the fluid time discretization, BDF, at order $$2$$, is the method we use.
+For the fluid time discretization, BDF, at order stem:[2], is the method we use.
 
 And Newmark-beta method is the one we choose for the structure time
-discretization, with parameters $$\gamma=0.5$$ and $$\beta=0.25$$.
+discretization, with parameters stem:[\gamma=0.5] and stem:[\beta=0.25].
 
-These methods can be retrieved in link:{biblio}#bloodflowChabannes[Chabannes] papers.
+These methods can be retrieved in <<Chabannes>> papers.
 
 === Solvers
 
@@ -169,102 +151,65 @@ Here are the different solvers ( linear and non-linear ) used during results acq
 
 |===
 3+|
-$$
-\text{KSP}
-$$
+KSP
 |case|fluid|solid
 |type 2+|
-$$
-\text{gmres}
-$$
+gmres
 |relative tolerance 2+|
-$$
-1e-13
-$$
-|max iteration|$$30$$|$$10$$
+stem:[1e-13]
+|max iteration|stem:[30]|stem:[10]
 |reuse preconditioner|true|false
 |===
 
 |===
 3+|
-$$
-\text{SNES}
-$$
+SNES
 |case|fluid|solid
 |relative tolerance 2+|
-$$
-1e-8
-$$
+stem:[1e-8]
 |steps tolerance 2+|
-$$
-1e-8
-$$
-|max iteration 2+|$$
-50
-$$
+stem:[1e-8]
+|max iteration 2+|
+stem:[50]
 |max iteration with reuse 2+|
-$$
-50
-$$
+stem:[50]
 |reuse jacobian 2+|
-$$
-\text{false}
-$$
+false
 |reuse jacobian rebuild at first Newton step|false|true
 |===
 
 |===
 3+|
-$$
-\text{KSP in SNES}
-$$
+KSP in SNES
 |case|fluid|solid
 |relative tolerance 2+|
-$$
-1e-5
-$$
+stem:[1e-5]
 |max iteration 2+|
-$$
-1000
-$$
+stem:[1000]
 |max iteration with reuse 2+|
-$$
-1000
-$$
+stem:[1000]
 |reuse preconditioner|true|false
 |reuse preconditioner rebuild at first Newton step 2+|
-$$
-\text{false}
-$$
+false
 |===
 
 |===
 3+|
-$$
-\text{PC}
-$$
+PC
 |case|fluid|solid
 |type 2+|
-$$
-\text{lu}
-$$
+LU
 |package 2+|
-$$
-\text{mumps}
-$$
+mumps
 |===
 
 |===
 2+|
-$$
-\text{FSI}
-$$
+FSI
 |solver method|fix point
-|tolerance|$$1e-6$$
-|max iterations|$$1$$
+|tolerance|stem:[1e-6]
+|max iterations|stem:[1]
 |===
-
-
 
 
 == Implementation 
@@ -309,8 +254,7 @@ image::FlowEvolution.png[caption="Figure 4 : ", title="Evolution of the inflow a
 [[img-geometry5]]
 image::DispMagni.png[caption="Figure 5 : ", title="Maximum displacement magnitude", alt="Displacement Magnitude", width="400", align="center"]  
 
-To draw the next two figures, we define 60 sections $$\{x_i\}_{i=0}^{60}$$ with
-$$x_i=0.1i$$.
+To draw the next two figures, we define 60 sections stem:[\{x_i\}_{i=0}^{60}] with stem:[x_i=0.1i].
 [[img-geometry6]]
 image::AverPressure.png[caption="Figure 5 : ", title="Average pressure with the free outlet and the Windkessel model", alt="Average Pressure", width="700", align="center"]  
 
@@ -356,7 +300,7 @@ perturbations thanks to the 0D model.
 
 The average pressure and the fluid flow ( see figure 6 and 7 ) show us the same
 non-physiological phenomenons as before. The results we obtain are in
-accordance with the ones proposed by link:{biblio}#nobile2001numerical[Nobile].
+accordance with the ones proposed by <<Nobile>>.
 
 To end this benchmark, we will compare the two resolution algorithms used with
 the fluid-structure model : the implicit and the semi-implicit ones. The

--- a/04-learning/FSI/3DElasticTube/README.adoc
+++ b/04-learning/FSI/3DElasticTube/README.adoc
@@ -2,115 +2,94 @@
 :toc:
 :toc-placement: preamble
 :toclevels: 1
-:biblio: ../../Appendix/Bibliography/readme.adoc 
+//:biblio: ../../Appendix/Bibliography/readme.adoc
 
+:icons: font
+:stem: latexmath
+:imagesdir: .
 
-Computer codes, used for the acquisition of results, are from Vincent link:{biblio}#bloodflowChabannes[Chabannes].
+Computer codes, used for the acquisition of results, are from Vincent <<Chabannes>>.
 
 == Problem Description 
 
-As in the link:../2DElasticTube/readme.adoc[2D case], the blood flow modelisation, by observing a pressure wave progression into a vessel, is the subjet of this benchmark. But this time, instead of a two-dimensional model, we use a three-dimensional model, with a cylinder
+As in the link:../2DElasticTube/README.adoc[2D case], the blood flow modelisation, by observing a pressure wave progression into a vessel, is the subjet of this benchmark.
+But this time, instead of a two-dimensional model, we use a three-dimensional model, with a cylinder
 
 [[img-geometry1]]
 image::3DElasticTube.png[caption="Figure 1 : ", title="Geometry of three-dimensional elastic tube.", alt="Elastic Tube Geometry", width="600", align="center"]  
 
-
-This represent the domains into the initial condition, with $$\Omega_f$$ and $$\Omega_s$$ respectively the fluid and the solid domain. The cylinder radius equals to $$r+\epsilon$$, where $$r$$ is the radius of the fluid domain and $$\epsilon$$ the part of the solid domain.
+This represents the domains into the initial condition, with stem:[\Omega_f] and stem:[\Omega_s] respectively the fluid and the solid domain.
+The cylinder radius equals to stem:[r+\epsilon], where stem:[r] is the radius of the fluid domain and stem:[\epsilon] the part of the solid domain.
 
 [[img-geometry2]]
 image::3DElasticTubeSection.png[caption="Figure 2 : ", title="Sections of the three-dimensional elastic tube.", alt="Elastic Tube Geometry", width="400", align="center"]  
 
-$$\Gamma^*_{fsi}$$ is the interface between the fluid and solid domains, whereas $$\Gamma^{e,*}_s$$ is the interface between the solid domain and the exterior. $$\Gamma_f^{i,*}$$ and $$\Gamma_f^{o,*}$$ are respectively the inflow and the outflow of the fluid domain. Likewise, $$\Gamma_s^{i,*}$$ and $$\Gamma_s^{o,*}$$ are the extremities of the solid domain
+stem:[\Gamma^*_{fsi}] is the interface between the fluid and solid domains, whereas stem:[\Gamma^{e,*}_s] is the interface between the solid domain and the exterior.
+stem:[\Gamma_f^{i,*}] and stem:[\Gamma_f^{o,*}] are respectively the inflow and the outflow of the fluid domain.
+Likewise, stem:[\Gamma_s^{i,*}] and stem:[\Gamma_s^{o,*}] are the extremities of the solid domain.
 
 During this benchmark, we will study two different cases, named BC-1 and BC-2, that differ from boundary conditions. BC-2 are conditions imposed to be more physiological than the ones from BC-1. So we waiting for more realistics based results from BC-2.
 
 === Boundary conditions
 
-* on $$\Gamma_f^{i,*}$$ the pressure wave pulse
-
-$$
+* on stem:[\Gamma_f^{i,*}] the pressure wave pulse
+\[
 \boldsymbol{\sigma}_{f} \boldsymbol{n}_f =
-  \left\{
-  \begin{aligned}
-    & \left(-\frac{1.3332 \cdot 10^4}{2} \left( 1 - \cos \left(  \frac{ \pi t} {1.5 \cdot 10^{-3}} \right) \right), 0 \right)^T \quad & \text{ si } t < 0.003 \\
-    & \boldsymbol{0} \quad & \text{ sinon }
-  \end{aligned}
-  \right.
-  $$
+\left\{
+\begin{aligned}
+& \left(-\frac{1.3332 \cdot 10^4}{2} \left( 1 - \cos \left(  \frac{ \pi t} {1.5 \cdot 10^{-3}} \right) \right), 0 \right)^T \quad & \text{ if } t < 0.003 \\
+& \boldsymbol{0} \quad & \text{ else }
+\end{aligned}
+\right.
+\]
   
-* We add the link:../readme.adoc#_fluid_structure_coupling_conditions[coupling conditions] on $$\Gamma^*_{fsi}$$ 
+* We add the link:../README.adoc[coupling conditions] on stem:[\Gamma^*_{fsi}]
 
-$$
+[stem]
+++++
   \frac{\partial \boldsymbol{\eta_{s}} }{\partial t} - \boldsymbol{u}_f \circ \mathcal{A}_{f}^t
   = \boldsymbol{0} , \quad \text{ on } \Gamma_{fsi}^* \times \left[t_i,t_f \right] \quad \boldsymbol{(1)}
-$$
+++++
 
-$$
+[stem]
+++++
   \boldsymbol{F}_{s} \boldsymbol{\Sigma}_{s} \boldsymbol{n}^*_s + J_{\mathcal{A}_{f}^t} \hat{\boldsymbol{\sigma}}_f \boldsymbol{F}_{\mathcal{A}_{f}^t}^{-T} \boldsymbol{n}^*_f
   = \boldsymbol{0} , \quad \text{ on } \Gamma_{fsi}^* \times \left[t_i,t_f \right] \quad \boldsymbol{(2)}
-$$
+++++
 
-$$
+[stem]
+++++
   \boldsymbol{\varphi}_s^t  - \mathcal{A}_{f}^t = \boldsymbol{0} , \quad \text{ on } \Gamma_{fsi}^* \times \left[t_i,t_f \right] \quad \boldsymbol{(3)}
-$$
+++++
 
 Then we have two different cases :
 
-- Case BC-1
-* on $$\Gamma_f^{o,*}$$
-    $$
-    \boldsymbol{\sigma}_{f} \boldsymbol{n}_f =0
-    $$
+* Case BC-1
 
-* on $$\Gamma_s^{i,*}$$U $$\Gamma_s^{o,*}$$ a null displacement
-$$
-\boldsymbol{\eta}_s=0
-$$
+** on stem:[\Gamma_f^{o,*}] : stem:[\boldsymbol{\sigma}_{f} \boldsymbol{n}_f =0]
 
-* on $$\Gamma^{e,*}_{s}$$ 
-$$
-\boldsymbol{F}_s\boldsymbol{\Sigma}_s\boldsymbol{n}_s^*=0
-$$
+** on stem:[\Gamma_s^{i,*} \cup \Gamma_s^{o,*}] a null displacement : stem:[\boldsymbol{\eta}_s=0]
 
-* on $$\Gamma_f^{i,*}$$U $$\Gamma_f^{o,*}$$
-$$
-\mathcal{A}^t_f=\boldsymbol{\mathrm{x}}^*
-$$
+** on stem:[\Gamma^{e,*}_{s}] : stem:[\boldsymbol{F}_s\boldsymbol{\Sigma}_s\boldsymbol{n}_s^*=0]
 
-- Case BC-2
-* on $$\Gamma_f^{o,*}$$
-    $$
-    \boldsymbol{\sigma}_{f} \boldsymbol{n}_f = -P_0\boldsymbol{n}_f
-    $$
+** on stem:[\Gamma_f^{i,*}$$U $$\Gamma_f^{o,*}] : stem:[\mathcal{A}^t_f=\boldsymbol{\mathrm{x}}^*]
 
-* on $$\Gamma_s^{i,*}$$ a null displacement
-$$
-\boldsymbol{\eta}_s=0
-$$
+* Case BC-2
+** on stem:[\Gamma_f^{o,*}] : stem:[\boldsymbol{\sigma}_{f} \boldsymbol{n}_f = -P_0\boldsymbol{n}_f]
 
-* on $$\Gamma^{e,*}_{s}$$ 
-$$
-\boldsymbol{F}_s\boldsymbol{\Sigma}_s\boldsymbol{n}_s^* + \alpha \boldsymbol{\eta}_s=0
-$$
+** on stem:[\Gamma_s^{i,*}] a null displacement stem:[\boldsymbol{\eta}_s=0]
 
-* on $$\Gamma^{o,*}_{s}$$ 
-$$
-\boldsymbol{F}_s\boldsymbol{\Sigma}_s\boldsymbol{n}_s^* =0
-$$
+** on stem:[\Gamma^{e,*}_{s}] : stem:[\boldsymbol{F}_s\boldsymbol{\Sigma}_s\boldsymbol{n}_s^* + \alpha \boldsymbol{\eta}_s=0]
 
-* on $$\Gamma_f^{i,*}$$
-$$
-\mathcal{A}^t_f=\boldsymbol{\mathrm{x}}^*
-$$
+** on stem:[\Gamma^{o,*}_{s}] : stem:[\boldsymbol{F}_s\boldsymbol{\Sigma}_s\boldsymbol{n}_s^* =0]
 
-* on $$\Gamma_f^{o,*}$$
-$$
-\nabla \mathcal{A}^t_f \boldsymbol{n}_f^*=\boldsymbol{n}_f^*
-$$
+** on stem:[\Gamma_f^{i,*}] : stem:[\mathcal{A}^t_f=\boldsymbol{\mathrm{x}}^*]
+
+** on stem:[\Gamma_f^{o,*}] : stem:[\nabla \mathcal{A}^t_f \boldsymbol{n}_f^*=\boldsymbol{n}_f^*]
 
 === Initial conditions
 
-The chosen time step is $$\Delta t=0.0001$$
+The chosen time step is stem:[\Delta t=0.0001]
 
 == Inputs
 
@@ -119,25 +98,25 @@ The chosen time step is $$\Delta t=0.0001$$
 |===
 | Name |Description | Nominal Value | Units
 
-|$$E_s$$ | Young's modulus | $$3 \times 10^6 $$  | $$dynes/cm^2$$
-|$$\nu_s$$ | Poisson's ratio | $$0.3$$  |dimensionless
-|$$r$$|fluid tube radius|0.5|$$cm$$
-|$$\epsilon$$|solid tube radius|0.1|$$cm$$
-|$$L$$|tube length|5|$$cm$$
-|$$A$$|A coordinates|(0,0,0)|$$cm$$
-|$$B$$|B coordinates|(5,0,0)|$$cm$$
-|$$\mu_f$$ |viscosity | $$0.03$$ |$$poise$$ 
-|$$\rho_f$$ | density | $$1$$  | $$g/cm^3$$
-|$$R_p$$ | proximal resistance | $$400$$  | 
-|$$R_d$$ | distal resistance| $$6.2 \times 10^3$$  | 
-|$$C_d$$ | capacitance | $$2.72 \times 10^{-4}$$  |
+|stem:[E_s] | Young's modulus | stem:[3 \times 10^6 ]  | stem:[dynes.cm^{-2}]
+|stem:[\nu_s] | Poisson's ratio | stem:[0.3]  |dimensionless
+|stem:[r]|fluid tube radius|0.5|stem:[cm]
+|stem:[\epsilon]|solid tube radius|0.1|stem:[cm]
+|stem:[L]|tube length|5|stem:[cm]
+|stem:[A]|A coordinates|(0,0,0)|stem:[cm]
+|stem:[B]|B coordinates|(5,0,0)|stem:[cm]
+|stem:[\mu_f] |viscosity | stem:[0.03] |stem:[poise] 
+|stem:[\rho_f] | density | stem:[1]  | stem:[g.cm^{-3}]
+|stem:[R_p] | proximal resistance | stem:[400]  | 
+|stem:[R_d] | distal resistance| stem:[6.2 \times 10^3]  | 
+|stem:[C_d] | capacitance | stem:[2.72 \times 10^{-4}]  |
 |===
 
 == Outputs
 
-After solving the link:../readme.adoc#_fluid_structure_model[fluid struture model], we obtain $$(\mathcal{A}^t, \boldsymbol{u}_f, p_f, \boldsymbol{\eta}_s)$$ 
+After solving the link:../README.adoc[fluid struture model], we obtain stem:[(\mathcal{A}^t, \boldsymbol{u}_f, p_f, \boldsymbol{\eta}_s)] 
 
-with $$\mathcal{A}^t$$ the ALE map, $$\boldsymbol{u}_f$$ the fluid velocity, $$p_f$$ the fluid pressure and $$\boldsymbol\eta_s$$ the structure displacement
+with stem:[\mathcal{A}^t] the ALE map, stem:[\boldsymbol{u}_f] the fluid velocity, stem:[p_f] the fluid pressure and stem:[\boldsymbol\eta_s] the structure displacement.
 
 == Discretization
 
@@ -145,17 +124,17 @@ Here are the different configurations we worked on. The parameter Incomp define 
 [cols="1,1,1,3,3,3,3,3,3,1"]
 |===
 3.2+|Config 3+|Fluid 4+| Structure
-|$$N_{elt}$$|$$N_{geo}$$|$$N_{dof}$$|$$N_{elt}$$|$$N_{geo}$$|$$N_{dof}$$|Incomp
-3+|$$(1)$$|$$13625$$|$$1$$ $$(P2P1)$$|$$69836$$|$$12961$$|$$1$$|$$12876$$ $$(P1)$$|No
-3+|$$(2)$$|$$13625$$|$$1$$ $$(P2P1)$$|$$69836$$|$$12961$$|$$1$$|$$81536$$ $$(P1)$$|Yes
-3+|$$(3)$$|$$1609$$|$$2$$ $$(P3P2)$$|$$30744$$|$$3361$$|$$2$$|$$19878$$ $$(P2)$$|No
+|stem:[N_{elt}]|stem:[N_{geo}]|stem:[N_{dof}]|stem:[N_{elt}]|stem:[N_{geo}]|stem:[N_{dof}]|Incomp
+3+|stem:[(1)]|stem:[13625]|stem:[1~(P2P1)]|stem:[69836]|stem:[12961]|stem:[1]|stem:[12876~(P1)]|No
+3+|stem:[(2)]|stem:[13625]|stem:[1~(P2P1)]|stem:[69836]|stem:[12961]|stem:[1]|stem:[81536~(P1)]|Yes
+3+|stem:[(3)]|stem:[1609]|stem:[2~(P3P2)]|stem:[30744]|stem:[3361]|stem:[2]|stem:[19878~(P2)]|No
 |===
 
-For the structure time discretization, we will use Newmark-beta method, with parameters $$\gamma=0.5$$ and $$\beta=0.25$$.
+For the structure time discretization, we will use Newmark-beta method, with parameters stem:[\gamma=0.5] and stem:[\beta=0.25].
 
-And for the fluid time discretization, BDF, at order $$2$$, is the method we choose.
+And for the fluid time discretization, BDF, at order stem:[2], is the method we choose.
 
-These two methods can be found in link:{biblio}#bloodflowChabannes[Chabannes] papers.
+These two methods can be found in <<Chabannes>> papers.
 
 == Implementation 
 
@@ -179,10 +158,11 @@ The result files are then stored by default in
     applications/models/fsi/wavepressure3d/P2P1G1-P1G1/np_1
 ----
 
-All the files used  for this case can be found in this https://github.com/feelpp/feelpp/tree/develop/applications/models/solid/TurekHron[rep]
-[https://github.com/feelpp/feelpp/blob/develop/applications/models/fsi/wavepressure3d/straightpipe.geo[geo file],  https://github.com/feelpp/feelpp/blob/develop/applications/models/fsi/wavepressure3d/wavepressure3d.cfg[config file], 
-https://github.com/feelpp/feelpp/blob/develop/applications/models/fsi/wavepressure3d/wavepressure3d_fluid.json[fluid json file], 
-https://github.com/feelpp/feelpp/blob/develop/applications/models/fsi/wavepressure3d/wavepressure3d_solid.json[solid json file]].
+All the files used  for this case can be found in this https://github.com/feelpp/feelpp/tree/develop/toolboxes/solid/TurekHron[rep]
+[https://github.com/feelpp/feelpp/tree/develop/toolboxes/fsi/wavepressure3d/straightpipe.geo[geo file],
+https://github.com/feelpp/feelpp/tree/develop/toolboxes/fsi/wavepressure3d/wavepressure3d.cfg[config file],
+https://github.com/feelpp/feelpp/tree/develop/toolboxes/fsi/wavepressure3d/wavepressure3d_fluid.json[fluid json file],
+https://github.com/feelpp/feelpp/tree/develop/toolboxes/fsi/wavepressure3d/wavepressure3d_solid.json[solid json file]].
 
 == Results
 

--- a/04-learning/FSI/Lid-DrivenCavity/README.adoc
+++ b/04-learning/FSI/Lid-DrivenCavity/README.adoc
@@ -2,13 +2,17 @@
 :toc:
 :toc-placement: preamble
 :toclevels: 1
-:biblio: ../../Appendix/Bibliography/readme.adoc 
+//:biblio: ../../Appendix/Bibliography/readme.adoc
 
-This test case has originally been proposed by link:{bilbio}#mok2001partitioned[Mok & Wall].
+:icons: font
+:stem: latexmath
+:imagesdir: .
 
-Computer codes, used for the acquisition of results, are from Vincent link:{biblio}#bloodflowChabannes[Chabannes].
+This test case has originally been proposed by <<MokWall>>.
 
-This benchmark has aso been realized by link:{biblio}#gerbeau2003quasi[Gerbeau], link:{bilbio}#valdes2007nonlinear[Vàzquez], link:{bilbio}#kuttler2008fixed[Kuttler] and link:{bilbio}#kassiotis2011nonlinear[Kassiotis].
+Computer codes, used for the acquisition of results, are from Vincent <<Chabannes>>.
+
+This benchmark has aso been realized by <<Gerbeau>>, <<Vàzquez>>, <<Kuttler>> and <<Kassiotis>>.
 
 == Problem Description 
 
@@ -17,72 +21,59 @@ We study here an incompressible fluid flowing into a cavity, where its walls are
 [[img-geometry1]]
 image::LidDriven.png[caption="Figure 1 : ", title="Geometry of lid-driven cavity flow.", alt="LidDriven Geometry", width="600", align="center"]  
 
-The domain $$\Omega_f^*$$ is define by a square $$[0,1]^2$$, $$\Gamma^{i,*}_f$$ and $$\Gamma^{o,*}_f$$ are respectively the flow entrance and the flow outlet. A constant flow velocity, following the $$x$$ axis, will be imposed on $$\Gamma_f^{h,*}$$ border, while a null flow velocity will be imposed on $$\Gamma_f^{f,*}$$. This last point represent also a non-slip condition for the fluid.
+The domain stem:[\Omega_f^*] is define by a square stem:[ [0,1\]^2 ], stem:[\Gamma^{i,*}_f] and stem:[\Gamma^{o,*}_f] are respectively the flow entrance and the flow outlet.
+A constant flow velocity, following the stem:[x] axis, will be imposed on stem:[\Gamma_f^{h,*}] border, while a null flow velocity will be imposed on stem:[\Gamma_f^{f,*}]. This last point represent also a non-slip condition for the fluid.
 
-Furthermore, we add a structure domain, at the bottom of the fluid one, named $$\Omega_s^*$$. It is fixed by his two vertical sides $$\Gamma_s^{f,*}$$, and we denote by $$\Gamma_f^{w,*}$$ the border which will interact with $$\Omega_f^*$$.
+Furthermore, we add a structure domain, at the bottom of the fluid one, named stem:[\Omega_s^*]. It is fixed by his two vertical sides stem:[\Gamma_s^{f,*}], and we denote by stem:[\Gamma_f^{w,*}] the border which will interact with stem:[\Omega_f^*].
 
-
-During this test, we will observe the displacement of a point $$A$$, positioned at $$(0;0.5)$$, into the $$y$$ direction, and compare our results to ones found in other references.
+During this test, we will observe the displacement of a point stem:[A], positioned at stem:[(0;0.5)], into the stem:[y] direction, and compare our results to ones found in other references.
 
 === Boundary conditions 
 
 Before enunciate the boundary conditions, we need to describe a oscillatory velocity, following the $$x$$ axis and dependent of time.
 
-$$
+[stem]
+++++
   v_{in} = 1-cos\left( \frac{2\pi t}{5} \right)
-$$
+++++
 
 Then we can set 
 
-* on $$\Gamma^{h,*}_f$$, an inflow Dirichlet condition.
-$$
-\boldsymbol{u}_{f} = ( v_{in}, 0 )
-$$
+* on stem:[\Gamma^{h,*}_f], an inflow Dirichlet condition : stem:[\boldsymbol{u}_{f} = ( v_{in}, 0 )]
 
-* on $$\Gamma^{i,*}_f$$, an inflow Dirichlet condition.
-$$
-\boldsymbol{u}_{f} = ( v_{in}(8 y -7) ,0)
-$$ 
+* on stem:[\Gamma^{i,*}_f], an inflow Dirichlet condition : stem:[\boldsymbol{u}_{f} = ( v_{in}(8 y -7) ,0)]
 
-* on $$\Gamma^{f,*}_f$$, a homogeneous Dirichlet condition. 
-$$
-\boldsymbol{u}_{f} = \boldsymbol{0}
-$$
+* on stem:[\Gamma^{f,*}_f], a homogeneous Dirichlet condition : stem:[\boldsymbol{u}_{f} = \boldsymbol{0}]
 
-* on $$\Gamma^{o,*}_f$$, a Neumann condition
-$$
-\boldsymbol{\sigma}_{f} \boldsymbol{n}_f = \boldsymbol{0}
-$$ 
+* on stem:[\Gamma^{o,*}_f], a Neumann condition : stem:[\boldsymbol{\sigma}_{f} \boldsymbol{n}_f = \boldsymbol{0}]
 
-* on $$\Gamma^{f,*}_s$$, a condition that imposes this boundary to be fixed.
-$$
-\boldsymbol{\eta}_{s} = \boldsymbol{0}
-$$
+* on stem:[\Gamma^{f,*}_s], a condition that imposes this boundary to be fixed : stem:[\boldsymbol{\eta}_{s} = \boldsymbol{0}]
 
-* on $$\Gamma^{e,*}_s$$, a condition that lets these boundaries be free from constraints.
-$$
-\boldsymbol{F}_{s} \boldsymbol{\Sigma}_s \boldsymbol{n}_s = \boldsymbol{0}
-$$
+* on stem:[\Gamma^{e,*}_s], a condition that lets these boundaries be free from constraints : stem:[\boldsymbol{F}_{s} \boldsymbol{\Sigma}_s \boldsymbol{n}_s = \boldsymbol{0}]
 
-To them we also add the fluid-structure coupling conditions on $$\Gamma_{fsi}^*$$
+To them we also add the fluid-structure coupling conditions on stem:[\Gamma_{fsi}^*] : 
 
-$$
+[stem]
+++++
 \frac{\partial \boldsymbol{\eta_{s}} }{\partial t} - \boldsymbol{u}_f \circ \mathcal{A}^t_f
   = \boldsymbol{0} \quad \left( \text{Velocities continuity}\right) 
-$$
-$$
+++++
+
+[stem]
+++++
   \boldsymbol{F}_{s} \boldsymbol{\Sigma}_{s} \boldsymbol{n}^*_s + J_{\mathcal{A}^t_f} \boldsymbol{F}_{\mathcal{A}^t_f}^{-T} \hat{\boldsymbol{\sigma}}_f \boldsymbol{n}^*_f
   = \boldsymbol{0} \quad \left( \text{ Constraint continuity}\right) 
-$$
+++++
 
-$$
+[stem]
+++++
   \boldsymbol{\varphi}_s^t  - \mathcal{A}^t_f
   = \boldsymbol{0} \quad \left( \text{Geometric continuity}\right) 
-$$
+++++
 
 === Initial conditions
 
-To realize the simulations, we used a time step $$\Delta t$$ equals to $$0.01$$ s.
+To realize the simulations, we used a time step stem:[\Delta t] equals to stem:[0.01] s.
     
 == Inputs
 
@@ -93,35 +84,35 @@ parameters of this test-case.
 .Fixed and Variable Input Parameters
 |===
 | Name |Description | Nominal Value | Units
-|$$E_s$$ | Young's modulus | $$250 $$  | $$N/m^2$$
-|$$\nu_s$$ | Poisson's ratio | $$0$$  | dimensionless
-|$$\rho_s$$ | structure density | $$500$$  |$$kg/m^3$$
-|$$\mu_f$$ |viscosity | $$1\times 10^{-3}$$  |$$m^2/s$$ 
-|$$\rho_f$$ | density | $$1$$ | $$kg/m^3$$
+|stem:[E_s] | Young's modulus | stem:[250]  | stem:[N.m^{-2}]
+|stem:[\nu_s] | Poisson's ratio | stem:[0]  | dimensionless
+|stem:[\rho_s] | structure density | stem:[500]  |stem:[kg.m^{-3}]
+|stem:[\mu_f] |viscosity | stem:[1\times 10^{-3}]  |stem:[m^2.s^{-1}] 
+|stem:[\rho_f] | density | stem:[1] | stem:[kg.m^{-3}]
 |===
 
 == Outputs
-$$(\boldsymbol{u}_f, p_f, \boldsymbol{\eta}_s, \mathcal{A}_f^t)$$, checking the link:../readme.adoc#_fluid_structure_model[fluid-structure system],  are the output of this problem.
+stem:[(\boldsymbol{u}_f, p_f, \boldsymbol{\eta}_s, \mathcal{A}_f^t)], checking the link:../README.adoc[fluid-structure system],  are the output of this problem.
 
 == Discretization
 
-To discretize space, we used $$P_N$$-$$P_{N-1}$$ Taylor-Hood finite elements.
+To discretize space, we used stem:[P_N~-~P_{N-1}] Taylor-Hood finite elements.
 
-For the structure time discretization,  Newmark-beta method is the one we used. And for the fluid time discretization, we used BDF, at order $$q$$.
+For the structure time discretization,  Newmark-beta method is the one we used. And for the fluid time discretization, we used BDF, at order stem:[q].
 
 == Implementation 
 
-All the codes files are into feelpp/FSI
+All the codes files are into https://github.com/feelpp/feelpp/tree/develop/toolboxes/feel/feelmodels/fsi[FSI]
 
 == Results
 
-We begin with a $$P_2P_1$$ approximation for the fluid with a geometry order equals at $$1$$, and a fluid-structure stable interface.
+We begin with a stem:[P_2~-~P_1] approximation for the fluid with a geometry order equals at stem:[1], and a fluid-structure stable interface.
 
 |===
 |
 |===
 
-Then we retry with a $$P_3P_2$$ approximation for the fluid with a geometry order equals at $$2$$, and a fluid-structure stable interface.
+Then we retry with a stem:[P_3~-~P_2] approximation for the fluid with a geometry order equals at stem:[2], and a fluid-structure stable interface.
 
 |===
 |

--- a/04-learning/FSI/README.adoc
+++ b/04-learning/FSI/README.adoc
@@ -3,50 +3,55 @@
 :toc-placement: preamble
 :toclevels: 2
 
+:icons: font
+:stem: latexmath
+:imagesdir: .
+
 We will interest now to the different interactions a fluid and a structure can have together with specific conditions. 
 
 == Fluid structure model 
 
 To describe and solve our fluid-structure interaction problem, we need to define a model, which regroup structure model and fluid model parts.
 
-We have then in one hand link:../CFD/readme.adoc[the fluid equations], and in the other hand link:../CSM/readme.adoc[the structure equations].
+We have then in one hand link:../CFD/README.adoc[the fluid equations], and in the other hand link:../CSM/README.adoc[the structure equations].
 
 [[img-geometry1]]
 image::FSIModel.png[caption="Figure 1 : ", title="FSI case example", alt="FSI", width="500", align="center"] 
 
-The solution of this model are $$(\mathcal{A}^t, \boldsymbol{u}_f, p_f, \boldsymbol{\eta}_s)$$.
+The solution of this model are stem:[(\mathcal{A}^t, \boldsymbol{u}_f, p_f, \boldsymbol{\eta}_s)].
 
-{% include "git+https://github.com/feelpp/feelpp-book.git/en/03-modeling/FluidStructure/FSIModel.adoc" %}
-
+//{% include "git+https://github.com/feelpp/feelpp-book.git/en/03-modeling/FluidStructure/FSIModel.adoc" %}
 
 == ALE
 
 Generally, the solid mechanic equations are expressed in a Lagrangian frame, and the fluid part in Eulerian frame. To define and take in account the fluid domain displacement, we use a technique name ALE ( Arbitrary Lagrangian Eulerian ). This allow the flow to follow the fluid-structure interface movements and also permit us to have a different deformation velocity than the fluid one.
 
-Let denote $$\Omega^{t_0}$$ the calculation domain, and $$\Omega^t$$ the deformed domain at time $$t$$. As explain before, we want to conserve the Lagrangian and Eulerian characteristics of each part, and to do this, we introduce $$\mathcal{A}^t$$ the ALE map.
+Let denote stem:[\Omega^{t_0}] the calculation domain, and stem:[\Omega^t] the deformed domain at time stem:[t]. As explain before, we want to conserve the Lagrangian and Eulerian characteristics of each part, and to do this, we introduce stem:[\mathcal{A}^t] the ALE map.
 
-This map give us the position of $$x$$, a point in the deformed domain at time $$t$$ from the position of $$x^*$$ in the initial configuration $$\Omega^*$$.
+This map give us the position of stem:[x], a point in the deformed domain at time stem:[t] from the position of stem:[x^*] in the initial configuration stem:[\Omega^*].
 
 [[img-geometry2]]
 image::ALE.png[caption="Figure 2 : ", title="ALE map", alt="ALE", width="500", align="center"]  
 
-$$\mathcal{A}^t$$ is a homeomorphism, i.e. a continuous and bijective application we can define as 
+stem:[\mathcal{A}^t] is a homeomorphism, i.e. a continuous and bijective application we can define as 
 
-$$
+[stem]
+++++
 \begin{eqnarray*}
   \mathcal{A}^t : \Omega^* &\longrightarrow & \Omega^{t} \\
   \mathbf{x}^* &\longmapsto & \mathbf{x} \left(\mathbf{x}^*,t \right)  = \mathcal{A}^t \left(\mathbf{x}^*\right)
 \end{eqnarray*}
-$$
+++++
 
-We denote also  $$\forall \mathbf{x}^* \in \Omega^* $$, the application :
+We denote also  stem:[\forall \mathbf{x}^* \in \Omega^*], the application :
 
-$$
+[stem]
+++++
 \begin{eqnarray*}
 \mathbf{x} : \left[t_0,t_f \right] &\longrightarrow & \Omega^t \\
 t &\longmapsto & \mathbf{x} \left(\mathbf{x}^*,t \right)
 \end{eqnarray*}
-$$
+++++
 
 This ALE map can then be retrieve into the fluid-structure model. 
 

--- a/04-learning/FSI/Turek-Hron/README.adoc
+++ b/04-learning/FSI/Turek-Hron/README.adoc
@@ -3,29 +3,31 @@ Turek Hron FSI Benchmark
 :toc:
 :toc-placement: preamble
 :toclevels: 1
-:biblio: ../../Appendix/Bibliography/readme.adoc 
+//:biblio: ../../Appendix/Bibliography/readme.adoc
+
+:icons: font
+:stem: latexmath
+:imagesdir: .
 
 
-In order to validate our fluid-structure interaction solver, a benchmark, initially proposed by link:{biblio}#turek2006proposal[Turek and Hron], is realized.
+In order to validate our fluid-structure interaction solver, a benchmark, initially proposed by <<TurekHron>>, is realized.
 
-Computer codes, used for the acquisition of results, are from Vincent link:../../Appendix/Bibliography/readme.adoc#bloodflowChabannes[Chabannes].
+Computer codes, used for the acquisition of results, are from Vincent <<Chabannes>>.
 
-> **Note** This benchmark is linked to the link:../../CFD/Turek-Hron/readme.adoc[Turek Hron CFD] and link:../../CSM/Turek-Hron/readme.adoc[Turek Hron CSM ] benchmarks.
+> **Note** This benchmark is linked to the link:../../CFD/Turek-Hron/README.adoc[Turek Hron CFD] and link:../../CSM/Turek-Hron/README.adoc[Turek Hron CSM ] benchmarks.
 
 == Problem Description
 
-In this case, we want to study the flow of a laminar incrompressible flow around an elastic obstacle, fixed to a rigid cylinder, we combine here the study realized on link:../../CFD/Turek-Hron/readme.adoc[Turek Hron CFD benchmark] and link:../../CFD/Turek-Hron/readme.adoc[Turek Hron CSM benchmark].
-So a 2D model, representative of this state, is consider. 
+In this case, we want to study the flow of a laminar incrompressible flow around an elastic obstacle, fixed to a rigid cylinder, we combine here the study realized on link:../../CFD/Turek-Hron/README.adoc[Turek Hron CFD benchmark] and link:../../CFD/Turek-Hron/README.adoc[Turek Hron CSM benchmark]. So a 2D model, representative of this state, is considered. 
 
 [[img-geometry1]]
 image::TurekHronFSIGeometry.png[caption="Figure 1 : ", title="Geometry of the Turek & Hron FSI Benchmark.", alt="TurekHron Geometry", width="600", align="center"]  
 
-
-We denote $$\Omega_f^*$$ the fluid domain, represented by a rectangle of dimension $$[0,2.5] \times [0,0.41] $$. This domain is characterized by its density $$\rho_f$$ and its dynamic viscosity $$\mu_f$$. In this case, the fluid material we used is glycerin.
+We denote stem:[\Omega_f^*] the fluid domain, represented by a rectangle of dimension stem:[ [0,2.5\] \times [0,0.41\] ]. This domain is characterized by its density stem:[\rho_f] and its dynamic viscosity stem:[\mu_f]. In this case, the fluid material we used is glycerin.
 
 Furthermore, the model chosen to describe the flow is the incompressible Navier-Stockes model. It is defined by the conservation of momentum equation and the conservation of mass equation. We also have the material constitutive equation to take in account in this domain, as well as the harmonic extension operator for the fluid movement.
 
-On the other side, the structure domain, named $$\Omega_s^*$$, represent the hyperelastic bar, bound to the stationary cylinder. As we want to work in a Lagrangian frame, and by Newton's second law, the fundamental equation of the solid mechanic will be used. For the model, that our hyperelastic material follows, we use the Saint-Venant-Kirchhoff one, define with Lamé coefficients. These coefficients are obtained from the the Young's modulus $$E_s$$ and the Poisson's ratio $$\nu_s$$ of the material.
+On the other side, the structure domain, named stem:[\Omega_s^*], represent the hyperelastic bar, bound to the stationary cylinder. As we want to work in a Lagrangian frame, and by Newton's second law, the fundamental equation of the solid mechanic will be used. For the model, that our hyperelastic material follows, we use the Saint-Venant-Kirchhoff one, define with Lamé coefficients. These coefficients are obtained from the the Young's modulus stem:[E_s] and the Poisson's ratio stem:[\nu_s] of the material.
 
 All of these are then gather into the fluid-structure coupling system.
 
@@ -33,56 +35,50 @@ All of these are then gather into the fluid-structure coupling system.
 
 We set
 
-* on $$\Gamma_{in}^*$$, an inflow Dirichlet condition.
-$$
-  \boldsymbol{u}_f=(v_{in},0);
-$$
+* on stem:[\Gamma_{in}^*], an inflow Dirichlet condition : stem:[  \boldsymbol{u}_f=(v_{in},0);]
 
-* on $$\Gamma_{wall}^*$$ and $$\Gamma_{circ}^*$$, a homogeneous Dirichlet condition. 
-$$
-  \boldsymbol{u}_f=\boldsymbol{0};
-$$
+* on stem:[\Gamma_{wall}^* \cup \Gamma_{circ}^*], a homogeneous Dirichlet condition : stem:[\boldsymbol{u}_f=\boldsymbol{0};]
 
-* on $$\Gamma_{out}^*$$, a Neumann condition
-$$
-  \boldsymbol{\sigma}_f\boldsymbol{n}_f=\boldsymbol{0};
-$$
+* on stem:[\Gamma_{out}^*], a Neumann condition : stem:[\boldsymbol{\sigma}_f\boldsymbol{n}_f=\boldsymbol{0};]
 
-* on $$\Gamma_{fixe}^*$$, a condition that imposes this boundary to be fixed.
-$$
-  \boldsymbol{\eta}_s=0
-$$
+* on stem:[\Gamma_{fixe}^*], a condition that imposes this boundary to be fixed : stem:[\boldsymbol{\eta}_s=0;]
 
-* on $$\Gamma_{fsi}^*$$
+* on stem:[\Gamma_{fsi}^*] :
 
-$$
+[stem]
+++++
 \frac{\partial \boldsymbol{\eta_{s}} }{\partial t} - \boldsymbol{u}_f \circ \mathcal{A}^t_f
   = \boldsymbol{0} \quad \left( \text{Velocities continuity}\right) 
-$$
-$$
+++++
+
+[stem]
+++++
   \boldsymbol{F}_{s} \boldsymbol{\Sigma}_{s} \boldsymbol{n}^*_s + J_{\mathcal{A}^t_f} \boldsymbol{F}_{\mathcal{A}^t_f}^{-T} \hat{\boldsymbol{\sigma}}_f \boldsymbol{n}^*_f
   = \boldsymbol{0} \quad \left( \text{ Constraint continuity}\right) 
-$$
+++++
 
-$$
+[stem]
+++++
   \boldsymbol{\varphi}_s^t  - \mathcal{A}^t_f
   = \boldsymbol{0} \quad \left( \text{Geometric continuity}\right) 
-$$
+++++
 
-where $$\boldsymbol{n}_f$$ is the outer unit normal vector from $$\partial \Omega_f^*$$.
+where stem:[\boldsymbol{n}_f] is the outer unit normal vector from stem:[\partial \Omega_f^*].
 
 === Initial conditions
 
 ==== Fluid 
-In order to describe the flow inlet by $$\Gamma_{in}$$, a parabolic velocity profile is used. It can be expressed by
+In order to describe the flow inlet by stem:[\Gamma_{in}], a parabolic velocity profile is used. It can be expressed by
 
-$$
+[stem]
+++++
   v_{cst} = 1.5 \bar{U} \frac{4}{0.1681} y \left(0.41-y\right)
-$$
-where $$\bar{U}$$ is the mean inflow velocity.
+++++
+where stem:[\bar{U}] is the mean inflow velocity.
 
 However, to impose a progressive increase of this velocity profile, we define
-$$
+
+\[
   v_{in} =
   \left\{
   \begin{aligned}
@@ -90,11 +86,11 @@ $$
    & v_{cst}  \quad & \text{ otherwise }
   \end{aligned}
   \right.
-$$
+\]
 
 With t the time.
 
-Finally, we don't want a source term, so $$f_f\equiv 0$$.
+Finally, we don't want a source term, so stem:[f_f\equiv 0].
 
 == Inputs
 
@@ -106,40 +102,40 @@ parameters of this test-case.
 |===
 | Name |Description | Nominal Value | Units
 
-|$$l$$ | elastic structure length | $$0.35$$  |$$m$$
-|$$h$$ | elastic structure height | $$0.02$$  |$$m$$ |$$r$$ | cylinder radius | $$0.05$$  |$$m$$
-|$$C$$ | cylinder center coordinates | $$(0.2,0.2)$$|$$m$$
-|$$A$$ | control point coordinates | $$(0.2,0.2)$$|$$m$$
-|$$B$$ | point coordinates | $$(0.15,0.2)$$|$$m$$
-|$$E_s$$ | Young's modulus | $$5.6 \times 10^6$$  | $$kg/(ms^2)$$
-|$$\nu_s$$ | Poisson's ratio | $$0.4$$ | dimensionless
-|$$\rho_s$$ | structure density | $$1000$$  |$$kg/m^3$$
-|$$\nu_f$$ | kinematic viscosity | $$1\times 10^{-3}$$ |$$m^2/s$$ 
-|$$\mu_f$$ | dynamic viscosity | $$1$$  | $$kg/(m \times s)$$
-|$$\rho_f$$ | density | $$1000$$  | $$kg/m^3$$
-|$$f_f$$| source term | 0  | 
-|$$\bar{U}$$| mean inflow velocity|2|$$m/s$$
+|stem:[l] | elastic structure length | stem:[0.35]  |stem:[m]
+|stem:[h] | elastic structure height | stem:[0.02]  |stem:[m] |stem:[r] | cylinder radius | stem:[0.05]  |stem:[m]
+|stem:[C] | cylinder center coordinates | stem:[(0.2,0.2)]|stem:[m]
+|stem:[A] | control point coordinates | stem:[(0.2,0.2)]|stem:[m]
+|stem:[B] | point coordinates | stem:[(0.15,0.2)]|stem:[m]
+|stem:[E_s] | Young's modulus | stem:[5.6 \times 10^6]  | stem:[kg.m^{-1}s^{-2}]
+|stem:[\nu_s] | Poisson's ratio | stem:[0.4] | dimensionless
+|stem:[\rho_s] | structure density | stem:[1000]  |stem:[kg.m^{-3}]
+|stem:[\nu_f] | kinematic viscosity | stem:[1\times 10^{-3}] |stem:[m^2.s^{-1}] 
+|stem:[\mu_f] | dynamic viscosity | stem:[1]  | stem:[kg.m^{-1}.s^{-1}]
+|stem:[\rho_f] | density | stem:[1000]  | stem:[kg.m^{-3}]
+|stem:[f_f]| source term | 0  | 
+|stem:[\bar{U}]| mean inflow velocity|2|stem:[m.s^{-1}]
 |===
 
 As for solvers we used, Newton's method is chosen for the non-linear part and a direct method based on LU decomposition is selected for the linear part.
 
 == Outputs
 
-The quantities we observe during this benchmark are on one hand the lift and drag forces ( respectively $$F_L$$ and $$F_D$$ ), as well as the displacement, on $$x$$ and $$y$$ axis, of the point A is the second value that interest us here.
+The quantities we observe during this benchmark are on one hand the lift and drag forces ( respectively stem:[F_L] and stem:[F_D] ), as well as the displacement, on stem:[x] and stem:[y] axis, of the point A is the second value that interest us here.
 
-They are the solution of the link::../readme.adoc#_fluid_structure_model[fluid-structure system].
+They are the solution of the link::../README.adoc[fluid-structure system].
 
-This system also give us the ALE map $$\mathcal{A}_f^t$$.
+This system also give us the ALE map stem:[\mathcal{A}_f^t].
 
 == Discretization
 
-To realize these tests, we made the choice to used $$P_N$$-$$P_{N-1}$$ Taylor-Hood finite elements to discretize the space.
+To realize these tests, we made the choice to used stem:[P_N~-~P_{N-1}] Taylor-Hood finite elements to discretize the space.
 
-For the fluid time discretization, BDF, at order $$q$$, is the method we have chosen.
+For the fluid time discretization, BDF, at order stem:[q], is the method we have chosen.
 
-And finally Newmark-beta method is the one we used for the structure time discretization, with parameters $$\gamma=0.5$$ and $$\beta=0.25$$.
+And finally Newmark-beta method is the one we used for the structure time discretization, with parameters stem:[\gamma=0.5] and stem:[\beta=0.25].
 
-These methods can be retrieved in link:../../Appendix/Bibliography/readme.adoc#bloodflowChabannes[Chabannes] papers.
+These methods can be retrieved in <<Chabannes>> papers.
 
 === Solvers
 
@@ -147,98 +143,65 @@ Here are the different solvers ( linear and non-linear ) used during results acq
 
 |===
 3+|
-$$
-\text{KSP}
-$$
+KSP
 |case|fluid|solid
 |type 2+|
-$$
-\text{gmres}
-$$
+gmres
 |relative tolerance 2+|
-$$
-1e-13
-$$
+stem:[1e-13]
 |max iteration 2+|
-$$
-1000
-$$
+stem:[1000]
 |reuse preconditioner 2+|
-$$
-\text{true}
-$$
+true
 |===
 
 |===
 3+|
-$$
-\text{SNES}
-$$
+SNES
 |case|fluid|solid
 |relative tolerance 2+|
-$$
-1e-8
-$$
+stem:[1e-8]
 |steps tolerance 2+|
-$$
-1e-8
-$$
-|max iteration 2+|$$
-50
-$$
-|max iteration with reuse |$$50$$|$$10$$
+stem:[1e-8]
+|max iteration 2+|
+stem:[50]
+|max iteration with reuse |stem:[50]|stem:[10]
 |reuse jacobian | true | false
 |reuse jacobian rebuild at first Newton step|false|true
 |===
 
 |===
 3+|
-$$
-\text{KSP in SNES}
-$$
+SNES
 |case|fluid|solid
 |relative tolerance 2+|
-$$
-1e-5
-$$
+stem:[1e-5]
 |max iteration 2+|
-$$
-1000
-$$
-|max iteration with reuse |$$1000$$|$$10$$
+stem:[1000]
+|max iteration with reuse |stem:[1000]|stem:[10]
 |reuse preconditioner 2+|true
 |reuse preconditioner rebuild at first Newton step 2+|
-$$
-\text{true}
-$$
+true
 |===
 
 |===
 3+|
-$$
-\text{PC}
-$$
+PC
 |case|fluid|solid
 |type 2+|
-$$
-\text{lu}
-$$
+LU
 |package 2+|
-$$
-\text{mumps}
-$$
+mumps
 |===
 
 |===
 2+|
-$$
-\text{FSI}
-$$
+FSI
 |solver method|fix point with Aitken relaxation
-|tolerance|$$1e-6$$
-|max iterations|$$1000$$
-|initial $$\theta$$|$$0.98$$
-|minimum $$\theta$$|$$1e-12$$
+|tolerance|stem:[1e-6]
+|max iterations|stem:[1000]
+|initial stem:[\theta]|stem:[0.98]
+|minimum stem:[\theta]|stem:[1e-12]
 |===
 
 == Implementation
@@ -261,10 +224,11 @@ The result files are then stored by default in
 
 ----
     feel/applications/models/fsi/TurekHron/fsi3/
-    velocity_space""pression_space""Geometric_order"-"OrderDisp""Geometric_order"/"processor_used"
+    <velocity_space><pression_space><Geometric_order>-<OrderDisp><Geometric_order>/np_<processor_used>
 ----
 
-For example, for the FSI3 case executed on $$4$$ processors, with a $$P_2$$ velocity approximation space, a $$P_1$$ pressure approximation space, a geometric order of $$1$$ for fluid part and a $$P_1$$ displacement approximation space and geometric order equals to $$1$$ for solid part, the path is 
+For example, for the FSI3 case executed on stem:[4] processors, with a stem:[P_2] velocity approximation space, a stem:[P_1] pressure approximation space, 
+a geometric order of stem:[1] for fluid part and a stem:[P_1] displacement approximation space and geometric order equals to stem:[1] for solid part, the path is 
 
 ----
     feel/applications/models/fsi/TurekHron/fsi3/P2P1G1-P1G1/np_4
@@ -276,12 +240,12 @@ First at all, we will discretize the simulation parameters for the different cas
 
 .Simulation parameters
 |===
-||$$N_{elt}$$|$$N_{dof}$$|$$[P^N_c(\Omega_{f,\delta}]^2 \times P^{N-1}_c(\Omega_{f,\delta}) \times V^{N-1}_{s,\delta}$$|$$\Delta t$$
+||stem:[N_{elt}]|stem:[N_{dof}]|stem:[ [P^N_c(\Omega_{f,\delta}\]^2 \times P^{N-1}_c(\Omega_{f,\delta}) \times V^{N-1}_{s,\delta}]|stem:[\Delta t]
 |link:../../Appendix/Bibliography/readme.adoc#turek2006proposal[Turek and Hron]|15872|304128||0.00025
-|(1)|1284|27400|$$[P^4_c(\Omega_{f,(h,3)}]^2 \times P^3_c(\Omega_{f,(h,3)}) \times V^3_{s,(h,3)}$$|0.005
-|(2)|2117|44834|$$[P^4_c(\Omega_{f,(h,3)}]^2 \times P^3_c(\Omega_{f,(h,3)}) \times V^3_{s,(h,3)}$$|0.005
-|(3)|4549|95427|$$[P^4_c(\Omega_{f,(h,3)}]^2 \times P^3_c(\Omega_{f,(h,3)}) \times V^3_{s,(h,3)}$$|0.005
-|(4)|17702|81654|$$[P^2_c(\Omega_{f,(h,1)}]^2 \times P^1_c(\Omega_{f,(h,1)}) \times V^1_{s,(h,1)}$$|0.0005
+|(1)|1284|27400|stem:[ [P^4_c(\Omega_{f,(h,3)}\]^2 \times P^3_c(\Omega_{f,(h,3)}) \times V^3_{s,(h,3)}]|0.005
+|(2)|2117|44834|stem:[ [P^4_c(\Omega_{f,(h,3)}\]^2 \times P^3_c(\Omega_{f,(h,3)}) \times V^3_{s,(h,3)}]|0.005
+|(3)|4549|95427|stem:[ [P^4_c(\Omega_{f,(h,3)}\]^2 \times P^3_c(\Omega_{f,(h,3)}) \times V^3_{s,(h,3)}]|0.005
+|(4)|17702|81654|stem:[ [P^2_c(\Omega_{f,(h,1)}\]^2 \times P^1_c(\Omega_{f,(h,1)}) \times V^1_{s,(h,1)}]|0.0005
 |===
 
 Then the FSI3 benchmark results are detailed below.
@@ -289,23 +253,23 @@ Then the FSI3 benchmark results are detailed below.
 [cols="1,2,2,2,2"]
 .Results for FSI3
 |===
-||$$x$$ displacement $$[\times 10^{-3}]$$|$$y$$ displacement $$[\times 10^{-3}]$$|Drag|Lift
-|link:../../Appendix/Bibliography/readme.adoc#turek2006proposal[Turek and Hron]|-2.69 ± 2.53 [10.9]|1.48 ± 34.38 [5.3]|457.3 ± 22.66 [10.9]|2.22 ± 149.78 [5.3]
-|link:../../Appendix/Bibliography/readme.adoc#breuer2012fluid[Breuer]|||464.5 ± 40.50|6.00 ± 166.00 [5.5]
-|link:../../Appendix/Bibliography/readme.adoc#turek2010numerical[Turek and Hron 2]|-2.88 ± 2.72 [10.9]|1.47 ± 34.99 [5.5]|460.5 ± 27.74 [10.9]|2.50 ± 153.91 [5.5]
-|link:../../Appendix/Bibliography/readme.adoc#munsch2010numerical[MunschBreuer]|-4.54 ± 4.34 [10.1]|1.50 ± 42.50 [5.1]|467.5 ± 39.50 [10.1]|16.2 ± 188.70 [5.1]
-|link:../../Appendix/Bibliography/readme.adoc#gallinger2010effiziente[Gallinger]|||474.9 ± 28.10|3.90 ± 165.90 [5.5]
-|link:../../Appendix/Bibliography/readme.adoc#sandboge2010fluid[Sandboge]|-2.83 ± 2.78 [10.8]|1.35 ± 34.75 [5.4]|458.5 ± 24.00 [10.8]|2.50 ± 147.50 [5.4]
+||stem:[x] displacement stem:[ [\times 10^{-3}\] ]|stem:[y] displacement stem:[ [\times 10^{-3}\] ]|Drag|Lift
+|<<TurekHron>>|-2.69 ± 2.53 [10.9]|1.48 ± 34.38 [5.3]|457.3 ± 22.66 [10.9]|2.22 ± 149.78 [5.3]
+|<<Breuer>>|||464.5 ± 40.50|6.00 ± 166.00 [5.5]
+|<<TurekHron2>>|-2.88 ± 2.72 [10.9]|1.47 ± 34.99 [5.5]|460.5 ± 27.74 [10.9]|2.50 ± 153.91 [5.5]
+|<<MunschBreuer>>|-4.54 ± 4.34 [10.1]|1.50 ± 42.50 [5.1]|467.5 ± 39.50 [10.1]|16.2 ± 188.70 [5.1]
+|<<Gallinger>>|||474.9 ± 28.10|3.90 ± 165.90 [5.5]
+|<<Sandboge>>|-2.83 ± 2.78 [10.8]|1.35 ± 34.75 [5.4]|458.5 ± 24.00 [10.8]|2.50 ± 147.50 [5.4]
 |(1)|-2.86 ± 2.74 [10.9]|1.31 ± 34.71 [5.4]|459.7 ± 29.97 [10.9]|4.46 ± 172.53 [5.4]
 |(2)|-2.85 ± 2.72 [10.9]|1.35 ± 34.62 [5.4]|459.2 ± 29.62 [10.9]|3.53 ± 172.73 [5.4]
 |(3)|-2.88 ± 2.75 [10.9]|1.35 ± 34.72 [5.4]|459.3 ± 29.84 [10.9]|3.19 ± 171.20 [5.4]
 |(4)|-2.90 ± 2.77 [11.0]|1.33 ± 34.90 [5.5]|457.9 ± 31.79 [11.0]|8.93 ± 216.21 [5.5]
 |===
 
-All the files used  for this case can be found in this https://github.com/feelpp/feelpp/tree/develop/applications/models/solid/TurekHron[rep]
-[https://github.com/feelpp/feelpp/tree/develop/applications/models/fsi/TurekHron/fsi.geo[geo file], https://github.com/feelpp/feelpp/tree/develop/applications/models/fsi/TurekHron/fsi3.cfg[config file],
-https://github.com/feelpp/feelpp/tree/develop/applications/models/fsi/TurekHron/fsi3_fluid.json[fluid json file],
-https://github.com/feelpp/feelpp/tree/develop/applications/models/fsi/TurekHron/fsi3_solid.json[solid json file]].
+All the files used  for this case can be found in this https://github.com/feelpp/feelpp/tree/develop/toolboxes/solid/TurekHron[rep]
+[https://github.com/feelpp/feelpp/tree/develop/toolboxes/fsi/TurekHron/fsi.geo[geo file], https://github.com/feelpp/feelpp/tree/develop/toolboxes/fsi/TurekHron/fsi3.cfg[config file],
+https://github.com/feelpp/feelpp/tree/develop/toolboxes/fsi/TurekHron/fsi3_fluid.json[fluid json file],
+https://github.com/feelpp/feelpp/tree/develop/toolboxes/fsi/TurekHron/fsi3_solid.json[solid json file]].
 
 
 === Conclusion
@@ -315,7 +279,7 @@ Our first three results are quite similar to given references values. That show 
 However, the lift force seems to undergo some disturbances, compared to reference results, and it's more noticeable in our fourth case.
 This phenomenon is describe by <<Beuer>>, where they're explaining these disturbances are caused by Aitken dynamic relaxation, used in fluid structure relation for the fixed point algorithm.
 
-In order to correct them, they propose to lower the fixed point tolerance, but this method also lowers calculation performances. An other method to solve this deviation is to use a fixed relaxation parameter $$\theta$$. In this case, the optimal $$\theta$$ seems to be equal to $$0.5$$.
+In order to correct them, they propose to lower the fixed point tolerance, but this method also lowers calculation performances. An other method to solve this deviation is to use a fixed relaxation parameter stem:[\theta]. In this case, the optimal $$\theta$$ seems to be equal to stem:[0.5].
 
 == Bibliography
 

--- a/toolbox-fsi.adoc
+++ b/toolbox-fsi.adoc
@@ -1,5 +1,5 @@
 = Fluid-Structure Interaction
-Vincent Chabannes <https://github.com/vincentchabannes[@vincentchabannes];Christophe Prud'homme <https://github.com/prudhomm[@prudhomm]>
+Vincent Chabannes <https://github.com/vincentchabannes[@vincentchabannes]>;Christophe Prud'homme <https://github.com/prudhomm[@prudhomm]>
 v1.0, 2017/02/20
 :page-layout!: 
 :page-permalink: /toolbox/fsi/


### PR DESCRIPTION
@prudhomm  @vincentchabannes  All equations, figures, links and bibliography are correctly displayed now in section `04-learning/FSI`. The content has not changed.