### PR TITLE
Error of typo

### DIFF
--- a/docs/math/modules/calculus/pages/change_of_variable.adoc
+++ b/docs/math/modules/calculus/pages/change_of_variable.adoc
@@ -95,7 +95,7 @@ The previous calculus becomes
 Denote stem:[f: K \mapsto \mathbb{R}] and stem:[\hat{f}: \hat{K} \mapsto \mathbb{R}] such that stem:[\hat{f} = f \circ F] and 
 ]\mathbf{F}: K \mapsto \mathbb{R}^d] and stem:[\mathbf{\hat{F}}: \hat{K} \mapsto \mathbb{R}^d] such that stem:[\hat{\mathbf{F}} = \mathbf{F} \circ \chi^e].
 
-Moreover denote  stem:[\mathbf{n}] the local outward normal to stem:[\Omega] and stem:[\mathbf{n}] the local outward normal to stem:[\hat{\Omega}].
+Moreover denote  stem:[\mathbf{n}] the local outward normal to stem:[\Omega] and stem:[\mathbf{n}^{st}] the local outward normal to stem:[\hat{\Omega}].
   
 we have the following relations
 


### PR DESCRIPTION
It's not "stem:[\mathbf{n}] the local outward normal to stem:[\hat{\Omega}]" but "stem:[\mathbf{n}^{st}] the local outward normal to stem:[\hat{\Omega}]" in the section "Some change of variable formulas"