### PR TITLE
Configure module order

### DIFF
--- a/site-dev.yml
+++ b/site-dev.yml
@@ -84,7 +84,7 @@ antora:
   - '@antora/collector-extension'
 asciidoc:
   attributes:
-    page-component-order: '!home, !ROOT, *'
+    page-component-order: '!home, !ROOT, user, dev, data, math, toolboxes, cases, *'
     version: 0.110
     feelpp-git-tag: develop
     deploymentRoot: ""

--- a/site.yml
+++ b/site.yml
@@ -105,7 +105,7 @@ antora:
   - '@antora/collector-extension'
 asciidoc:
   attributes:
-    page-component-order: '!home, !ROOT, *'
+    page-component-order: '!home, !ROOT, user, dev, data, math, toolboxes, cases, *'
     page-pagination: ''
     kroki-fetch-diagram: true
     feelpp-git-tag: develop


### PR DESCRIPTION
|Before|After|
|---|---|
|![current](https://github.com/feelpp/book.feelpp.org/assets/333276/36486f5f-2795-497b-9c35-cf0f21db4716)|![new](https://github.com/feelpp/book.feelpp.org/assets/333276/d4f86e80-420f-4b81-a4ff-7a513b7fa7ac)|

I feel like "Feel++" is redundant in the module title, no?

Here's another proposal without "Feel++":

|Before|After|
|---|---|
|![current](https://github.com/feelpp/book.feelpp.org/assets/333276/36486f5f-2795-497b-9c35-cf0f21db4716)|![image](https://github.com/feelpp/book.feelpp.org/assets/333276/25d3326e-f649-4f51-a176-fb73a5787744)|


#### Open questions

- Should we move "Toolbox Contribution Guide" after "Toolbox Cases Guide"?
- Do we want to keep "Template Project" in the navigation?
- Should we move AgioTK after "Salome integration"?
