### PR TITLE
Upgrade asciidoctor-jupyter to 0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@feelpp/asciidoctor-remote-include-processor": "^0.0.6",
         "asciidoctor": "^2.2.6",
         "asciidoctor-emoji": "^0.4.2",
-        "asciidoctor-jupyter": "^0.4.0",
+        "asciidoctor-jupyter": "^0.5.0",
         "asciidoctor-kroki": "^0.16.0",
         "handlebars-utils": "^1.0.6",
         "node-srv": "^3.0.3"
@@ -491,9 +491,9 @@
       }
     },
     "node_modules/asciidoctor-jupyter": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asciidoctor-jupyter/-/asciidoctor-jupyter-0.4.0.tgz",
-      "integrity": "sha512-yEJe2EW63NKRbEmtSrabaUnuJtHALcYZPr7uiULkbsjlFX0YvIWhE/aUAEv3M4cf5ebcjWQaGzCDV6mokTs7Tg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/asciidoctor-jupyter/-/asciidoctor-jupyter-0.5.0.tgz",
+      "integrity": "sha512-goiigV5j62Quwdb1WV3zmhfV/A6vF0Od1YVPAoLsb5xbj/6Xtv770RCL/TDEzCNiPjg6+61DtYd7riYhskBaRw==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -3213,9 +3213,9 @@
       "requires": {}
     },
     "asciidoctor-jupyter": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asciidoctor-jupyter/-/asciidoctor-jupyter-0.4.0.tgz",
-      "integrity": "sha512-yEJe2EW63NKRbEmtSrabaUnuJtHALcYZPr7uiULkbsjlFX0YvIWhE/aUAEv3M4cf5ebcjWQaGzCDV6mokTs7Tg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/asciidoctor-jupyter/-/asciidoctor-jupyter-0.5.0.tgz",
+      "integrity": "sha512-goiigV5j62Quwdb1WV3zmhfV/A6vF0Od1YVPAoLsb5xbj/6Xtv770RCL/TDEzCNiPjg6+61DtYd7riYhskBaRw==",
       "dev": true
     },
     "asciidoctor-kroki": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@feelpp/asciidoctor-remote-include-processor": "^0.0.6",
     "asciidoctor": "^2.2.6",
     "asciidoctor-emoji": "^0.4.2",
-    "asciidoctor-jupyter": "^0.4.0",  
+    "asciidoctor-jupyter": "^0.5.0",  
     "asciidoctor-kroki": "^0.16.0",
     "handlebars-utils": "^1.0.6",
     "node-srv": "^3.0.3"


### PR DESCRIPTION
- Reduce verbosity
- Support more block/inline types (xref, example, colist)

### Before

```
asciidoctor: WARNING: Unsupported inline_anchor type: xref, ignoring.
asciidoctor: WARNING: Unsupported inline_anchor type: xref, ignoring.
asciidoctor: WARNING: Unsupported node: sidebar, ignoring.
asciidoctor: WARNING: Unsupported inline_anchor type: xref, ignoring.
```

### After
```
asciidoctor: WARNING: Unsupported nodes [sidebar, inline_anchor>ref], some content might be missing!
```