### PR TITLE
Saigre/fix typos in python

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "asciidoc.antora.enableAntoraSupport": true
+}

--- a/docs/dev/modules/reference/pages/Mesh/README.adoc
+++ b/docs/dev/modules/reference/pages/Mesh/README.adoc
@@ -81,14 +81,14 @@ Optional Parameters:
 |===
 | Name | Type | Description | Default Value | Option
 
-| `_hsize`  |double | characteristic size of the mesh. This option will edit the `.geo` file and change the variable `h` if defined | 0.1 | `gmsh.hsize`
-| `_geo_variables_list` | string | Set a list of variable that may be defined in a `.geo` file| "" | `gmsh.geo`-variables-list
-| `_filename` |string | filename with extension | `feel.geo`| `gmsh.filename`
-| `_depends`  |string | list of files (separated by , or ;) on which `gmsh.filename` depends| ""|`gmsh.depends`
-| `_refine` | boolean| optionally refine with \p refine levels the mesh.| `0.`| `gmsh.refine`
-| `_update` | integer | update the mesh data structure (build internal faces and edges)| `true`
-| `_physical_are_elementary_regions` | boolean | to load specific meshes formats.| `false.`| gmsh.physical_are_elementary_regions
-|`_straighten` | boolean | in case of curvilinear elements, straighten the elements which are not touching with a face the boundary of the domain| `true`| `gmsh.straighten`
+| `_hsize` | double | characteristic size of the mesh. This option will edit the `.geo` file and change the variable `h` if defined | 0.1 | `gmsh.hsize`
+| `_geo_variables_list` | string | Set a list of variable that may be defined in a `.geo` file | "" | `gmsh.geo`-variables-list
+| `_filename` | string | filename with extension | `feel.geo`| `gmsh.filename`
+| `_depends`  | string | list of files (separated by , or ;) on which `gmsh.filename` depends | "" |`gmsh.depends`
+| `_refine` | boolean | optionally refine with \p refine levels the mesh.| `0.` | `gmsh.refine`
+| `_update` | integer | update the mesh data structure (build internal faces and edges) | `true` |
+| `_physical_are_elementary_regions` | boolean | to load specific meshes formats.| `false.` | gmsh.physical_are_elementary_regions
+|`_straighten` | boolean | in case of curvilinear elements, straighten the elements which are not touching with a face the boundary of the domain| `true` | `gmsh.straighten`
 | `_partitioner` | integer | define the mesh partitioner to use | `1` (if Metis is available) `0` if not (CHACO) | gmsh.partitioner
 
 |===

--- a/docs/dev/modules/reference/pages/fileformats.adoc
+++ b/docs/dev/modules/reference/pages/fileformats.adoc
@@ -34,8 +34,8 @@ Feel++ supports various file formats that can be used as output mesh and data fi
 | `gmsh`  |  Gmsh mesh file format | Read/Write | Ascii/Binary
 | `ensightgold` | Ensight  Gold case format | Write | Binary
 | `h3d`  |  H3D  file format | Read | Database
-| `xdmf` | XML/HDF5 file format | Write
-| `VTK`   | VTK file format | Write
+| `xdmf` | XML/HDF5 file format | Write |
+| `VTK`   | VTK file format | Write |
 |===
 
 WARNING: The H3D file format requires that you have the Altair Hypermesh software installed.

--- a/docs/feelppdocs/modules/ROOT/pages/acknowledgments.adoc
+++ b/docs/feelppdocs/modules/ROOT/pages/acknowledgments.adoc
@@ -26,7 +26,7 @@ IRMIA::
  - Hifimagnet (2012-2018)
 
 MESR::
-  - PhD Lorenzo Sala on eye2brain (2016-2019) 
+  - PhD Lorenzo Sala on eye2brain (2016-2019)
 
 AMIES::
  - PEPS Holo3
@@ -53,7 +53,7 @@ IRMIA(Labex)::
   - PhD Romain Hild on High Field Magnets (2015-2020)
   - Research Engineer position (2021-2022)
   - 4fastsim (2016-2017)
-  
+
 PRACE projects::
  - HP-FEEL++ 2015-2016
  - HP-FEEL++ 2013-2014
@@ -61,7 +61,7 @@ PRACE projects::
 
 Regional::
   - Région Grand Est - Calcul clusterisé - 2018-2020
-  - Rhônes-Alpes region, cluster ISLE <<fn:2>> and the project CHPID (2009-2011)
+  - Rhônes-Alpes region, cluster ISLE and the project CHPID (2009-2011)
 
 == Contributors
 

--- a/docs/math/modules/fem/pages/hom/index.adoc
+++ b/docs/math/modules/fem/pages/hom/index.adoc
@@ -1,4 +1,4 @@
-= High-Order Discretization Mini‑App and Mathematical Framework
+= High-Order Discretization Mini-App and Mathematical Framework
 2025-02-13
 :icons: font
 :sectnums:
@@ -7,18 +7,18 @@
 
 == Overview
 
-This document describes our effort to develop a portable mini‑app for high‑order discretizations using Kokkos (targeting both CPUs and GPUs) and a mathematical framework that unifies a wide range of methods, drawing inspiration from the Feel++ project. In our work we combine two complementary ideas:
+This document describes our effort to develop a portable mini-app for high-order discretizations using Kokkos (targeting both CPUs and GPUs) and a mathematical framework that unifies a wide range of methods, drawing inspiration from the Feel++ project. In our work we combine two complementary ideas:
 
-* A **mini‑app** that encapsulates the core high‑order discretization kernels.
-* A **proxy‑app** that serves as a simplified version of a full‑scale application, emphasizing performance‑critical operations.
+* A **mini-app** that encapsulates the core high-order discretization kernels.
+* A **proxy-app** that serves as a simplified version of a full-scale application, emphasizing performance-critical operations.
 
-Furthermore, we take inspiration from the ECP’s development of [libCEED concepts](https://libceed.org/en/latest/libCEEDapi/), which guide our low‑level operator design.
+Furthermore, we take inspiration from the ECP’s development of [libCEED concepts](https://libceed.org/en/latest/libCEEDapi/), which guide our low-level operator design.
 
-== Mini‑App
+== Mini-App
 
-A *mini‑app* is a lightweight application designed to capture the essential computational patterns of a complex code base without the full implementation overhead. Our mini‑app:
+A *mini-app* is a lightweight application designed to capture the essential computational patterns of a complex code base without the full implementation overhead. Our mini-app:
 
-* Implements high‑order discretizations for partial differential equations.
+* Implements high-order discretizations for partial differential equations.
 * Leverages Kokkos to ensure performance portability across different hardware architectures (CPUs and GPUs).
 * Focuses on key computational kernels (e.g. basis function evaluation, operator assembly, and matrix–vector products).
 * Serves as a testbed to validate both the numerical methods and the performance optimizations.
@@ -33,27 +33,27 @@ A *mini‑app* is a lightweight application designed to capture the essential co
 \frac{1}{\rho c^2} \frac{\partial^2 u}{\partial t^2} -\nabla \cdot ( \frac{1}{\rho} \nabla u  )  = f
 ++++
 
-== Proxy‑App
+== Proxy-App
 
-A *proxy‑app* is a simplified, stand‑alone application that replicates the performance‑critical aspects of a full‑scale production code. In our context the proxy‑app:
+A *proxy-app* is a simplified, stand-alone application that replicates the performance-critical aspects of a full-scale production code. In our context the proxy-app:
 
 * Emulates the discretization workflow by assembling the key operators.
 * Is used to benchmark and tune performance on various hardware configurations.
-* Provides an environment for exploring 
-** various finite element libraries 
+* Provides an environment for exploring
+** various finite element libraries
 ** optimization strategies (such as tuning Kokkos execution policies) without the complexity of a complete application.
-* Acts as a bridge between the mini‑app’s numerical kernels and a full‑scale solver.
+* Acts as a bridge between the mini-app’s numerical kernels and a full-scale solver.
 
 == LibCEED and Its Concepts
 
-The Exascale Computing Project (ECP) developed libCEED to provide a lightweight, efficient, and portable API for high‑order finite element discretizations. The libCEED approach is based on a few key concepts:
+The Exascale Computing Project (ECP) developed libCEED to provide a lightweight, efficient, and portable API for high-order finite element discretizations. The libCEED approach is based on a few key concepts:
 
-* **Element Restriction:** Maps global degrees of freedom into element‑local data, enabling efficient local operator evaluations.
+* **Element Restriction:** Maps global degrees of freedom into element-local data, enabling efficient local operator evaluations.
 * **Basis Evaluation:** Offers routines to evaluate finite element basis functions (and their derivatives) at quadrature points.
-* **QFunctions:** Encapsulates the action of local operators as small user‑defined functions that are independent of the global assembly process.
+* **QFunctions:** Encapsulates the action of local operators as small user-defined functions that are independent of the global assembly process.
 * **Operator Assembly:** Provides a modular framework to compose element restrictions, basis evaluations, and QFunctions into a complete discretized operator.
 
-These design ideas allow libCEED to separate the mathematical formulation from the hardware‑specific optimizations. In our work, we follow similar principles to create a mathematical framework that supports a broad range of methods (as seen in Feel++) while keeping the user API as stable as possible.
+These design ideas allow libCEED to separate the mathematical formulation from the hardware-specific optimizations. In our work, we follow similar principles to create a mathematical framework that supports a broad range of methods (as seen in Feel++) while keeping the user API as stable as possible.
 
 Questions:
 
@@ -85,7 +85,7 @@ ReferenceElement triangleReference( "triangle", { {0,0}, {1,0}, {0,1} } );
 
 The primal basis is a set of polynomials defined on the reference element. These polynomials (for example, Dubiner, Legendre, or canonical monomials) provide the building blocks for the finite element space.
 
-For a given reference element, let stem:[\{ p_0, p_1, \dots, p_n \}] be the set of polynomial basis functions. In 
+For a given reference element, let stem:[\{ p_0, p_1, \dots, p_n \}] be the set of polynomial basis functions. In
 
 [stem]
 ++++
@@ -121,7 +121,7 @@ The construction process involves:
 === Portable High-Order Discretization with Kokkos
 
 To achieve performance portability across CPUs and GPUs, FEEL++ leverages Kokkos. Kokkos provides:
-  
+
 * **Portable Data Structures:** For example, using `Kokkos::View` for storing the polynomial coefficients.
 * **Parallel Execution:** Parallel loops for evaluating basis functions and assembling element operators.
 * **Memory Abstraction:** The same code can run on different architectures without major modifications.
@@ -132,5 +132,5 @@ in GPU recomputing can be critical. see Geos proxy app. @kfelix @stefano ?
 
 == References
 
-* [libCEED API Documentation](https://libceed.org/en/latest/libCEEDapi/) – An example of how low‑level operator abstractions are defined for high‑order methods.
+* [libCEED API Documentation](https://libceed.org/en/latest/libCEEDapi/) – An example of how low-level operator abstractions are defined for high-order methods.
 * FEEL++ documentation and source code for further details on the implementation.

--- a/docs/mor/modules/ROOT/pages/opusheat/index.adoc
+++ b/docs/mor/modules/ROOT/pages/opusheat/index.adoc
@@ -22,7 +22,7 @@ then solution of heat transfer equation :
 ++++
 \begin{equation}
   \label{eq:1}
-  \rho C_i \Big( \frac{\partial T}{\partial t} + \vec{v} \cdot \nabla T \Big) 
+  \rho C_i \Big( \frac{\partial T}{\partial t} + \vec{v} \cdot \nabla T \Big)
       - \nabla \cdot \left( k_i \nabla T \right) = Q_i,\quad i=1,2,3,4
 \end{equation}
 ++++
@@ -165,7 +165,7 @@ The table displays the various fixed and variables parameters of this test-case.
 | Name     | Description | Nominal Value              | Units
 | stem:[t] | time        | stem:[[0, 500]]   | stem:[s]
 | stem:[T_0] | initial temperature | stem:[300]   | stem:[K]
-2+^| IC Parameters     2+| 
+2+^| IC Parameters     2+|
 | stem:[\rho C_{IC}] | heat capacity | stem:[1.4 \cdot 10^{6}] | stem:[J \cdot m^{-3} \cdot K^{-1}]
 | stem:[e_{IC}] | thickness |  stem:[2\cdot 10^{-3}] | stem:[m]
 | stem:[h_{IC} = L_{IC}] | height | stem:[2\cdot 10^{-2}] | stem:[m]
@@ -179,9 +179,9 @@ The table displays the various fixed and variables parameters of this test-case.
 | stem:[h_{Pcb}] | height | stem:[13\cdot 10^{-2}] | stem:[m]
 4+|
 2+^| Air Parameters 2+|
-| stem:[T_0]        | Inflow temperature   | stem:[300]             | stem:[K] 
+| stem:[T_0]        | Inflow temperature   | stem:[300]             | stem:[K]
 | stem:[k_4 ]       | thermal conductivity | stem:[3 \cdot 10^{-2}] | stem:[W \cdot m^{-1} \cdot K^{-1}]
-| stem:[\rho C_{4}] | heat capacity        | stem:[1100]|           | stem:[J \cdot m^{-3} \cdot K^{-1}]
+| stem:[\rho C_{4}] | heat capacity        | stem:[1100]            | stem:[J \cdot m^{-3} \cdot K^{-1}]
 | stem:[e_{a}]      | thickness            |  stem:[4\cdot 10^{-3}] | stem:[m]
 |=======================================================================
 

--- a/docs/toolboxes/modules/ROOT/pages/modeling-analysis-using-json-files.adoc
+++ b/docs/toolboxes/modules/ROOT/pages/modeling-analysis-using-json-files.adoc
@@ -390,8 +390,9 @@ g(f)=\frac{f-average(f)}{max(f)-min(f)}
 }
 ----
 The previous snippet JSON will generate two normalizations of the distance function by using :
-* min_max method with default range stem:[\left[0,1\right]] : generated symbol is `meshes_<mesh_id>_distanceToRange_walls_normalized_min_max`.
-* mean method : generated symbol is `meshes_<mesh_id>_distanceToRange_walls_normalized_mean`.
+
+* `min_max` method with default range stem:[\[0, 1\]] : generated symbol is `meshes_<mesh_id>_distanceToRange_walls_normalized_min_max`.
+* `mean` method : generated symbol is `meshes_<mesh_id>_distanceToRange_walls_normalized_mean`.
 
 .Example 2 of DistanceToRange normalisation setup
 [source,json]
@@ -403,7 +404,7 @@ The previous snippet JSON will generate two normalizations of the distance funct
   }
 }
 ----
-The previous snippet JSON will generated one normalization Min-Max of the distance function on interval stem:[\left[1,2\rifht]].
+The previous snippet JSON will generated one normalization Min-Max of the distance function on interval stem:[\[1,2\]].
 
 
 .Example 3 of DistanceToRange normalisation setup
@@ -1207,7 +1208,7 @@ The quadrature order used in the norm computed can be also given if an analytica
 <11> coordinates of the point
 <12> fields to be computed at the point coordinate
 
-Here is a   xref:cases:csm:rotating-winch/index.adoc[biele example] from the Toolbox examples.
+Here is a xref:cases:csm:rotating-winch/index.adoc[biele example] from the Toolbox examples.
 
 
 == The generator of cases by using the index definitions

--- a/docs/toolboxes/modules/cfpdes/partials/introduction.adoc
+++ b/docs/toolboxes/modules/cfpdes/partials/introduction.adoc
@@ -6,7 +6,7 @@
 
 Coefficient forms in PDE (Partial Differential Equation) toolboxes refer to the representation of the PDE problem in terms of its coefficient functions. In the context of PDEs, the coefficients represent the properties and characteristics of the equation, such as the diffusion coefficient, convection coefficient, reaction coefficient, and others.
 
-Different types of PDEs, such as elliptic, parabolic, or hyperbolic equations, have specific coefficient forms associated with them. 
+Different types of PDEs, such as elliptic, parabolic, or hyperbolic equations, have specific coefficient forms associated with them.
 These coefficient forms capture the behavior and physical properties of the underlying phenomena being modeled.
 
 For example, in the context of the Poisson equation, a commonly encountered elliptic equation, the coefficient form is often written as:
@@ -16,16 +16,16 @@ For example, in the context of the Poisson equation, a commonly encountered elli
 -\nabla \cdot (c \nabla u) + a u = f
 ++++
 
-Here, 
+Here,
 
-* stem:[c] represents the diffusion coefficient, 
-* stem:[a] represents the reaction coefficient, 
-* stem:[u] is the unknown function, and 
-* stem:[f] is the source term. 
+* stem:[c] represents the diffusion coefficient,
+* stem:[a] represents the reaction coefficient,
+* stem:[u] is the unknown function, and
+* stem:[f] is the source term.
 
 The coefficient form provides a structured way to express the PDE problem and allows for efficient numerical solution techniques.
 
-PDE toolboxes, such as those available in {feelpp}, provide functionality to handle coefficient forms of various PDEs. 
+PDE toolboxes, such as those available in {feelpp}, provide functionality to handle coefficient forms of various PDEs.
 They offer tools for defining the coefficient functions, setting boundary conditions, discretizing the problem, and solving it numerically using appropriate algorithms and methods.
 
 By utilizing coefficient forms in PDE toolboxes, researchers and engineers can conveniently formulate and solve complex PDE problems with the necessary coefficients and boundary conditions, enabling the analysis and simulation of a wide range of physical phenomena.
@@ -86,10 +86,10 @@ We need also to respect some constraint on the coefficient shape as described in
 
 | stem:[d]      | scalar               | scalar
 | stem:[c]      | scalar or matrix    | scalar or matrix
-| stem:[\alpha] | vectorial            | scalar or matrix 
-| stem:[\gamma] | vectorial            | matrix 
-| stem:[\beta]  | vectorial            | vectorial 
-| stem:[a]      | scalar               | scalar 
+| stem:[\alpha] | vectorial            | scalar or matrix
+| stem:[\gamma] | vectorial            | matrix
+| stem:[\beta]  | vectorial            | vectorial
+| stem:[a]      | scalar               | scalar
 | stem:[f]      | scalar               | vectorial
 
 |===
@@ -161,7 +161,7 @@ NOTE: In the following, `mu` is a parameter defined e.g. in the `Parameters` sec
                     "alpha": "x*y*mu:x:y:mu", // scalar
                     "alpha": "{x,y,y,x*mu}:x:y:mu", // 2D matrix
                     "gamma": "{x,y,y,x}:x:y", // 2D matrix
-                    "beta": "{t+x,y}:x:y:t", 
+                    "beta": "{t+x,y}:x:y:t",
                     "a": "x+y:x:y",
                     "f": "{x,x+y*t}:x:y:t"
                 }
@@ -207,16 +207,16 @@ NOTE: the shape of the initial condition must be the same as the unknown shape.
 
 Here are supported boundary conditions
 
-=== Dirichlet 
+=== Dirichlet
 
-Dirichlet boundary condition is a type of boundary condition commonly used in partial differential equations. 
-It specifies the value of the solution at the boundary of the domain. 
-In other words, it prescribes the behavior of the solution at the boundary. 
+Dirichlet boundary condition is a type of boundary condition commonly used in partial differential equations.
+It specifies the value of the solution at the boundary of the domain.
+In other words, it prescribes the behavior of the solution at the boundary.
 
 The condition may depend  on the space variable stem:[x], time stem:[t], parameters stem:[\mu] and other unknowns stem:[u_1, \dots, u_N] than the current one.
 
-For example, in a heat transfer problem, a Dirichlet boundary condition may specify the temperature at the boundary of the domain. 
-In a fluid flow problem, a Dirichlet boundary condition may specify the velocity or pressure at the boundary. 
+For example, in a heat transfer problem, a Dirichlet boundary condition may specify the temperature at the boundary of the domain.
+In a fluid flow problem, a Dirichlet boundary condition may specify the velocity or pressure at the boundary.
 
 The Dirichlet boundary condition is essential in determining a unique solution to a PDE problem. Without it, the solution would be underdetermined, and there would be an infinite number of solutions that satisfy the PDE.
 
@@ -228,7 +228,7 @@ The shape of the Dirichlet condition is the same as the unknown shape.
 [stem]
 ++++
 \begin{eqnarray*}
-u_i = g_i(x,t,\mu), \quad i=1,\dots,N 
+u_i = g_i(x,t,\mu), \quad i=1,\dots,N
 \end{eqnarray*}
 ++++
 ****
@@ -237,14 +237,14 @@ The user provides the expression for stem:[(g_i)_{i=1\dots N}] in the `.json` fi
 
 === Neumann
 
-Neumann boundary condition is another type of boundary condition commonly used in partial differential equations. 
-It specifies the normal derivative of the solution at the boundary of the domain. 
+Neumann boundary condition is another type of boundary condition commonly used in partial differential equations.
+It specifies the normal derivative of the solution at the boundary of the domain.
 In other words, it prescribes the flux of the solution across the boundary.
 
-For example, in a heat transfer problem, a Neumann boundary condition may specify the heat flux at the boundary of the domain. 
-In a fluid flow problem, a Neumann boundary condition may specify the normal stress or shear stress at the boundary. 
+For example, in a heat transfer problem, a Neumann boundary condition may specify the heat flux at the boundary of the domain.
+In a fluid flow problem, a Neumann boundary condition may specify the normal stress or shear stress at the boundary.
 
-The Neumann boundary condition is also essential in determining a unique solution to a PDE problem. 
+The Neumann boundary condition is also essential in determining a unique solution to a PDE problem.
 It provides additional information about the behavior of the solution at the boundary, which complements the Dirichlet boundary condition. Together, the Dirichlet and Neumann boundary conditions form a complete set of boundary conditions that fully specify the PDE problem.
 
 The Neumann conditions may depend  on the space variable stem:[x], time stem:[t], parameters stem:[\mu] and the unknowns stem:[u_1, \dots, u_N].
@@ -266,12 +266,12 @@ The user provides the expression for stem:[(g_i)_{i=1\dots N}] in the `.json` fi
 
 === Robin
 
-Robin boundary condition is a type of boundary condition that combines both Dirichlet and Neumann boundary conditions. 
-It specifies a linear combination of the solution and its normal derivative at the boundary of the domain. 
-In other words, it prescribes both the value and the flux of the solution at the boundary. 
+Robin boundary condition is a type of boundary condition that combines both Dirichlet and Neumann boundary conditions.
+It specifies a linear combination of the solution and its normal derivative at the boundary of the domain.
+In other words, it prescribes both the value and the flux of the solution at the boundary.
 
-For example, in a heat transfer problem, a Robin boundary condition may specify a heat transfer coefficient that relates the temperature difference between the boundary and the surrounding medium to the heat flux at the boundary. 
-In a fluid flow problem, a Robin boundary condition may specify a slip coefficient that relates the velocity difference between the boundary and the surrounding medium to the shear stress at the boundary. 
+For example, in a heat transfer problem, a Robin boundary condition may specify a heat transfer coefficient that relates the temperature difference between the boundary and the surrounding medium to the heat flux at the boundary.
+In a fluid flow problem, a Robin boundary condition may specify a slip coefficient that relates the velocity difference between the boundary and the surrounding medium to the shear stress at the boundary.
 
 The Robin boundary condition is useful in modeling situations where the boundary is in contact with a medium that has a different thermal or mechanical behavior than the domain. It provides a more realistic and accurate description of the physical problem than using only Dirichlet or Neumann boundary conditions.
 
@@ -300,16 +300,13 @@ Here's an example of an asciidoc table with a list of finite elements supported 
 
 |===
 | Finite Element | polynomial order | Description
-
 | Pch<k> | 0,1,2 | Piecewise continuous scalar functions of arbitrary degree stem:[k]
 | Pchv<k>| 0,1,2 | Piecewise continuous vectorial functions of arbitrary degree stem:[k]
-
 | RT<k> | k=0 | Raviart-Thomas element of degree stem:[k]
-| NED<k> | Nedelec's first family of curl-conforming elements
-
+| NED<k> | | Nedelec's first family of curl-conforming elements
 |===
 
-This table lists various finite elements supported by {cfpdes}, along with a brief description of each element. 
+This table lists various finite elements supported by {cfpdes}, along with a brief description of each element.
 
 NOTE: {feelpp} supports a wider range of finite elements, including piecewise arbitrary order polynomials, as well as mixed finite elements such as Raviart-Thomas and Brezzi-Douglas-Marini elements or Nedelec's first families.
 
@@ -322,7 +319,7 @@ The backward difference formula scheme is a numerical method for approximating t
 
 stem:[f'(x_n) ≈ \frac{1}{\Delta t} \left(\alpha f(x_n) + \beta f(x_{n-1}) + \gamma f(x_{n-2}) + \dots\right)]
 
-where stem:[\Delta t] is the time step size, stem:[x_n] is the point at which the derivative is approximated, and stem:[\alpha], stem:[\beta], stem:[\gamma], etc. are coefficients that depend on the order of the scheme. 
+where stem:[\Delta t] is the time step size, stem:[x_n] is the point at which the derivative is approximated, and stem:[\alpha], stem:[\beta], stem:[\gamma], etc. are coefficients that depend on the order of the scheme.
 
 For example, the first-order backward difference formula scheme is:
 
@@ -344,25 +341,25 @@ The theta scheme is a numerical method for solving partial differential equation
 \frac{u_i^{n+1} - u_i^n}{\Delta t} = \theta f(u_{i}^{n+1}) + (1-\theta)f(u_{i}^{n})
 ++++
 
-where stem:[u_i^n] is the numerical solution at the stem:[i]-th spatial point and stem:[n]-th time step, stem:[\Delta t] and stem:[\Delta x] are the time and spatial step sizes, and stem:[\theta] is a parameter that determines the weighting between the current and previous time steps. 
+where stem:[u_i^n] is the numerical solution at the stem:[i]-th spatial point and stem:[n]-th time step, stem:[\Delta t] and stem:[\Delta x] are the time and spatial step sizes, and stem:[\theta] is a parameter that determines the weighting between the current and previous time steps.
 
-When stem:[\theta=0], the scheme reduces to the backward difference formula, whereas when stem:[\theta=1], it reduces to the forward difference formula. 
+When stem:[\theta=0], the scheme reduces to the backward difference formula, whereas when stem:[\theta=1], it reduces to the forward difference formula.
 
 For stem:[\theta=0.5], the scheme is known as the **Crank-Nicolson scheme**, which is a popular choice due to its stability and accuracy. The theta scheme is widely used in numerical simulations of heat transfer, fluid flow, and other physical phenomena.
 
 == Stabilized finite element methods
-:adr: advection diffusion reaction 
+:adr: advection diffusion reaction
 
-Stabilized finite element methods are a class of numerical methods used to solve partial differential equations (PDEs). 
+Stabilized finite element methods are a class of numerical methods used to solve partial differential equations (PDEs).
 These methods are designed to overcome the limitations of traditional finite element methods, which can suffer from numerical instabilities and inaccuracies when applied to certain types of PDEs, such as those with convection-dominated or highly oscillatory solutions.
 
-Stabilized finite element methods introduce additional terms to the weak form of the PDE, which act as stabilizers to improve the accuracy and stability of the numerical solution. 
+Stabilized finite element methods introduce additional terms to the weak form of the PDE, which act as stabilizers to improve the accuracy and stability of the numerical solution.
 These terms are typically chosen to balance the effects of convection, diffusion, and reaction in the PDE, and to ensure that the numerical solution satisfies certain physical and mathematical constraints.
 
-There are several types of stabilized finite element methods, including **streamline diffusion**, **Petrov-Galerkin**, and **least-squares** methods. 
+There are several types of stabilized finite element methods, including **streamline diffusion**, **Petrov-Galerkin**, and **least-squares** methods.
 Each method has its own strengths and weaknesses, and the choice of method depends on the specific problem being solved.
 
-Stabilized finite element methods have been successfully applied to a wide range of PDE problems, including fluid dynamics, heat transfer, and structural mechanics. 
+Stabilized finite element methods have been successfully applied to a wide range of PDE problems, including fluid dynamics, heat transfer, and structural mechanics.
 They have also been used in the development of advanced simulation tools for engineering and scientific applications.
 
 {cfpdes} toolbox provides the possibility to use stabilized finite element methods (GaLS and SUPG) for equations such as the {adr} equation.
@@ -392,9 +389,9 @@ l(v) = \int_{\Omega} f v dx
 ++++
 
 
-Here, stem:[\epsilon], stem:[\beta], and stem:[\gamma] are positive constants that control the balance between diffusion, convection, and reaction in the PDE, and stem:[\alpha] is a positive constant that controls the strength of the stabilization term on the boundary. 
-The Galerkin least squares method introduces additional terms to the bilinear form that act as stabilizers to improve the accuracy and stability of the numerical solution. 
-These terms are chosen to minimize the residual of the PDE in a least squares sense, and are typically expressed in terms of the gradient of the solution and its higher-order derivatives. 
+Here, stem:[\epsilon], stem:[\beta], and stem:[\gamma] are positive constants that control the balance between diffusion, convection, and reaction in the PDE, and stem:[\alpha] is a positive constant that controls the strength of the stabilization term on the boundary.
+The Galerkin least squares method introduces additional terms to the bilinear form that act as stabilizers to improve the accuracy and stability of the numerical solution.
+These terms are chosen to minimize the residual of the PDE in a least squares sense, and are typically expressed in terms of the gradient of the solution and its higher-order derivatives.
 The Galerkin least squares method has been shown to be effective in solving a wide range of PDE problems, including convection-dominated and highly oscillatory problems.
 
 [stem]
@@ -403,8 +400,8 @@ a_{\text{GLS}}(u,v) = a(u,v) + \tau \int_{\Omega} \left( \epsilon \nabla u - \be
 ++++
 
 where stem:[\tau] is a positive constant that controls the strength of the stabilization term.
-The first term in the additional terms is a diffusion term that penalizes the gradient of the solution, while the second term is a convection term that penalizes the solution itself. 
-The third term is a reaction term that ensures that the numerical solution satisfies certain physical and mathematical constraints. 
+The first term in the additional terms is a diffusion term that penalizes the gradient of the solution, while the second term is a convection term that penalizes the solution itself.
+The third term is a reaction term that ensures that the numerical solution satisfies certain physical and mathematical constraints.
 The Galerkin least squares method with these additional terms has been shown to be effective in improving the accuracy and stability of the numerical solution for a wide range of PDE problems.
 
 === SUPG
@@ -420,21 +417,21 @@ where stem:[\tau] is a positive constant that controls the strength of the stabi
 
 === {cfpdes} toolbox
 
-Given a `cfpdes` equation  named `myeq`, SUPG and GaLS can be used as stabilisation methods. 
+Given a `cfpdes` equation  named `myeq`, SUPG and GaLS can be used as stabilisation methods.
 To enable them use, in the command-line or `.cfg` file, the option `cfpdes.eq.stabilitsation=1` and define the stabilisation type `cfpdes.eq.stabilitsation.type=gls #supg#unusual-gls #gls`
 
 .Stabilisation methods
 |===
-| type | 
+| type |
 
 
 | `gls`      | default option
-| `supg`      | 
-| `unusual-gls`  | 
+| `supg`      |
+| `unusual-gls`  |
 
 |===
 
-Examples are available https://github.com/feelpp/feelpp/tree/develop/toolboxes/coefficientformpdes/cases/adr[here] 
+Examples are available https://github.com/feelpp/feelpp/tree/develop/toolboxes/coefficientformpdes/cases/adr[here]
 
 
 == Next steps

--- a/docs/toolboxes/modules/heat/pages/toolbox.adoc
+++ b/docs/toolboxes/modules/heat/pages/toolbox.adoc
@@ -285,15 +285,15 @@ NOTE: The expressions given to the convective heat flux boundary condition can d
 === Radiative heat flux
 WARNING: Radiative heat transfer is not yet available in the toolboxes. An application implementing radiative heat is currently available in feelpp/doc/manual/heat.
 
-New sections in the JSON configuration file are necessary. 
+New sections in the JSON configuration file are necessary.
 Firstly, the "Coating" section, which contains information about the radiative properties of the emitting surfaces, especially the value of the emissivity constant stem:[\epsilon].
 
 .JSON properties of Coating section
 |===
 | Property | Description | Value Type | Is Optional
 
-| `markers` | list of mesh markers associated to a radiative surface | `string`, `array of string`  | no  
-| `epsilon`       | value of the emissivity of the radiative surface | `string` | no |
+| `markers` | list of mesh markers associated to a radiative surface | `string`, `array of string`  | no
+| `epsilon`       | value of the emissivity of the radiative surface | `string` | no
 |===
 
 [source,json]
@@ -307,7 +307,7 @@ Firstly, the "Coating" section, which contains information about the radiative p
         "epsilon": "0.5"
     }
 }
-}        
+}
 ----
 
 Secondly, the "radiative_enclosure_heat_flux" and "radiative_blackbody_heat_flux" sections, inside the "BoundaryConditions" section, which specify the decomposition of the radiating boundaries into cavities, independent of each other, open or closed, where the radiative boundary conditions are imposed.
@@ -317,8 +317,8 @@ Secondly, the "radiative_enclosure_heat_flux" and "radiative_blackbody_heat_flux
 | Property | Description | Value Type | Values | Is Optional
 
 | `enclosure` | Specifies if the cavity is isolated (closed) or if it communicates with a black body (open) | `string`  | `open`, `closed` | no
-| `markers`       | list of mesh markers associated to a radiative surface | `string`, `array of string`  |  |no  
-| `sigma`       | Stefan-Boltzmann constant | `string`, `array of string`  |  |no  
+| `markers`       | list of mesh markers associated to a radiative surface | `string`, `array of string`  |  |no
+| `sigma`       | Stefan-Boltzmann constant | `string`, `array of string`  |  |no
 | `Tref`     | Reference temperature of the black body (only for open enclosures) | `string`  |  | yes
 | `viewfactors` | Information for the computation/loading of view factors of the cavity | JSON  |  | no
 |===
@@ -328,15 +328,15 @@ Secondly, the "radiative_enclosure_heat_flux" and "radiative_blackbody_heat_flux
 | Property | Description | Value Type | Values | Is Optional
 
 | `status` | Specifies if view factors have to be computed or loaded from file | `string`  | `compute`, `load` | no
-| `filename`| File name for the computation of view factors (JSON format) or loading (CSV) | `string` |  |no  
+| `filename`| File name for the computation of view factors (JSON format) or loading (CSV) | `string` |  |no
 |===
 
 .JSON properties of the "radiative_blackbody_heat_flux/CavityName" section
 |===
 | Property | Description | Value Type | Values | Is Optional
 
-| `markers`       | list of mesh markers associated to a radiative surface | `string`, `array of string`  |  |no  
-| `sigma`       | Stefan-Boltzmann constant | `string`, `array of string`  |  |no  
+| `markers`       | list of mesh markers associated to a radiative surface | `string`, `array of string`  |  |no
+| `sigma`       | Stefan-Boltzmann constant | `string`, `array of string`  |  |no
 | `Tref`     | Reference temperature of the black body (only for open enclosures) | `string`  |  | yes
 |===
 
@@ -355,11 +355,11 @@ Secondly, the "radiative_enclosure_heat_flux" and "radiative_blackbody_heat_flux
                       "status":"load",
                       "filename":"$cfgdir/VF_Matrix_Cavity_1.csv"
                       // "status":"compute",
-                      // "filename":"$cfgdir/rectangular_cavity_vf.json"                        
+                      // "filename":"$cfgdir/rectangular_cavity_vf.json"
                   }
             }
           },
-        "radiative_blackbody_heat_flux": { 
+        "radiative_blackbody_heat_flux": {
                 "Gamma_BBC_1": {
                     "markers": ["Gamma_B_11","Gamma_B_12"],
                     "Tref": "Tref_C+273.15:Tref_C",
@@ -367,8 +367,8 @@ Secondly, the "radiative_enclosure_heat_flux" and "radiative_blackbody_heat_flux
                 }
         }
       }
-   }     
-}   
+   }
+}
 ----
 
 Finally, an additional JSON file per cavity is necessary if the view factor matrix needs to be computed. This file will specify the algorithm to be use in order to compute the view factors, and the markers forming the cavity.
@@ -377,10 +377,10 @@ Finally, an additional JSON file per cavity is necessary if the view factor matr
 |===
 | Property | Description | Value Type | Values | Is Optional
 
-| `type`       | Choose between raytracing (obstructed and non-obstructed cavities) and quadrature (only non-obstructed cavities)  | `string` |`Raytracing`, `UnobstructedPlanar`  |no  
+| `type`       | Choose between raytracing (obstructed and non-obstructed cavities) and quadrature (only non-obstructed cavities)  | `string` |`Raytracing`, `UnobstructedPlanar`  |no
 | `algorithm`     | Choose the algorithm (only for UnobstructedPlanar) between DoubleAreaIntegration (2D) and SingleAreaIntegration (3D) | `string` |`DoubleAreaIntegration`, `SingleAreaIntegration` | yes
 | `quadrature_order`  | Quadrature order (only for UnobstructedPlanar) | `int`  |  | yes
-| `markers`       | list of mesh markers associated to the cavity | `string`, `array of string`  |  |no  
+| `markers`       | list of mesh markers associated to the cavity | `string`, `array of string`  |  |no
 |===
 
 [source,json]
@@ -390,7 +390,7 @@ Finally, an additional JSON file per cavity is necessary if the view factor matr
          "type": "UnobstructedPlanar",
          "algorithm":"DoubleAreaIntegration",
          "quadrature_order":2,
-         "markers":["RadiativeSurface1", "RadiativeSurface2","RadiativeSurface3"],        
+         "markers":["RadiativeSurface1", "RadiativeSurface2","RadiativeSurface3"],
          "description": "The viewfactor of a closed triangular cavity."
      }
  }

--- a/docs/toolboxes/modules/mso4sc/pages/run.adoc
+++ b/docs/toolboxes/modules/mso4sc/pages/run.adoc
@@ -58,7 +58,7 @@ We detail the different field in the following tables. We differentiate the keys
 [options="header,footer"]
 |===
 | Key                           | Description                                 | Default                                                            | Notes
-| **feelpp_<toolbox>_case**   | string that describe the location of the testcase      | Depending on the toolbox |A default test-case is proposed but more are availbe in the Feel/toolbox repository                       |
+| **feelpp_<toolbox>_case**   | string that describe the location of the testcase      | Depending on the toolbox | A default test-case is proposed but more are availbe in the Feel/toolbox repository
 | **feelpp_<toolbox slug name>_cli**     | command line options       |  "" | For advanced usage only
 |===
 
@@ -108,7 +108,7 @@ include::{examplesdir}/remotedesktop.txt[]
 ** Click on *Create*
 ** Click either on *Desktop* or *View Only*
 
-[NOTE]: if no *Remote desktop* is defined, you will receive a warning message. Create a <<post, *Setting*>>, then go back to this step.
+NOTE: if no *Remote desktop* is defined, you will receive a warning message. Create a <<post, *Setting*>>, then go back to this step.
 
 It opens a new web page within your browser. You can now start visualization tolls such as paraview or ensight. Here is the procedure to start paraview, for more information on paraview see link:{https://www.paraview.org/documentation/}[*paraview documentation*].
 

--- a/docs/user/modules/install/pages/compile.adoc
+++ b/docs/user/modules/install/pages/compile.adoc
@@ -3,7 +3,7 @@ include::{partialsdir}/header-macros.adoc[]
 
 NOTE: {lvl_advanced}
 
-TIP: For beginners, you can skip this section and go directly to <<containers,containers>> section.
+TIP: For beginners, you can skip this section and go directly to xref:containers.adoc[containers] section.
 
 Before starting compiling {feelpp}, you need first to
 
@@ -61,7 +61,7 @@ $ cd feelpp/quickstart
 $ mpirun -np 4 feelpp_qs_laplacian_2d --case laplacian/feelpp2d
 ----
 
-=== Targets 
+=== Targets
 
 Here is a list of targets you might be interested in
 
@@ -69,7 +69,7 @@ To compile a specific target use the following command line
 
  $ cmake --build --preset default -t <target>
 
-[cols="1,1"] 
+[cols="1,1"]
 |===
 | Target | Description
 | feelpp | {feelpp} core library
@@ -207,10 +207,10 @@ $ cmake ../feelpp
 | None | |
 | Debug | `-g -O1` | Debug mode with slight optimization to ensure some performance but some objects may be optimized away while debugging
 | DebugFull | `-g -O0 -fno-omit-frame-pointer -fno-optimize-sibling-calls` | Debug without any optimization to avoid objects to be optimized away at the cost of performance
-| Release | `-O3 -DNDEBUG` | Optimize the code aggressively 
-| RelWithDebInfo |  `-g -O2 -DNDEBUG` | 
+| Release | `-O3 -DNDEBUG` | Optimize the code aggressively
+| RelWithDebInfo |  `-g -O2 -DNDEBUG` |
 | Asan | `-g -O1  -fsanitize=address,leak -fno-omit-frame-pointer -fno-optimize-sibling-calls` |  Enable Address and Leak Sanitizers
-| Coverage | `-g -O0 --coverage` | Enable Coverage Reporting for GCC/Clang 
+| Coverage | `-g -O0 --coverage` | Enable Coverage Reporting for GCC/Clang
 |===
 ====
 

--- a/docs/user/modules/install/pages/containers.adoc
+++ b/docs/user/modules/install/pages/containers.adoc
@@ -90,7 +90,7 @@ HPC infrastructure and address security issues in multi-user environments.
 It allows users to run applications in a portable and reproducible environment,
 making it ideal for scientific and engineering workflows.
 
-We now pull/push SIF images from/to GitHub Container Registry (ghcr.io). 
+We now pull/push SIF images from/to GitHub Container Registry (ghcr.io).
 Feel++ images can be found at the following link:
 https://github.com/feelpp/feelpp/pkgs/container/feelpp[> Feel++ Packages].
 
@@ -107,20 +107,20 @@ apptainer run feelpp-noble.sif feelpp_toolbox_fluid --version
 ----
 
 [NOTE]
-----
+====
 These images are also available for:
 
 * Ubuntu 22.04 (jammy): ghcr.io/feelpp/feelpp:v0.111.0-preview.10-jammy-sif
 * Ubuntu 20.04 (focal): ghcr.io/feelpp/feelpp:v0.111.0-preview.10-focal-sif
 * Debian 12 (bookworm): ghcr.io/feelpp/feelpp:v0.111.0-preview.10-bookworm-sif
-----
+====
 
 Apptainer works in a similar way to Docker. For example, you can
 download one of the images available on ghcr.io and run it interactively or execute specific commands within the container.
 
 Once downloaded, you can enter the container interactively with the command line:
 
-.Run the container interactively 
+.Run the container interactively
 [source,bash]
 ----
 apptainer shell feelpp-noble.sif
@@ -133,6 +133,6 @@ Or run a specific command:
 apptainer run feelpp-noble.sif feelpp_toolbox_fluid --version
 ----
 
-TIP: You can retrieve images from the GitHub Container Registry directly using 
+TIP: You can retrieve images from the GitHub Container Registry directly using
 `apptainer pull -F feelpp-noble.sif oras://ghcr.io/feelpp/feelpp:v0.111.0-preview.10-noble-sif`.
 Make sure to check for the latest versions and tags.

--- a/docs/user/modules/install/pages/index.adoc
+++ b/docs/user/modules/install/pages/index.adoc
@@ -25,7 +25,7 @@ sudo apt update
 Ubuntu::
 +
 --
-Ubuntu LTS distributions jammy (22.04-preferred) is supported.
+Ubuntu LTS distributions jammy(22.04-preferred) is supported.
 
 We may support short term distributions.
 
@@ -47,14 +47,18 @@ par::[ubuntu,jammy,latest]
 
 par::[ubuntu,focal,latest]
 
+
 The supported systems are described below
 [cols="1,1,1,1,2", options="header"]
 .Table {feelpp} Ubuntu distributions
 |===
 |Distribution | Release | Version | Supported Channels | Comment
+
 |ubuntu | noble | 24.04 | latest | LTS
 |ubuntu | jammy | 22.04 | latest | LTS
 |ubuntu | focal | 20.04 | latest | LTS
+
+
 |===
 
 include::partial$install-deb.adoc[]
@@ -69,6 +73,7 @@ Debian LTS distribution bookworm(12) is supported.
 
 The supported systems are described below
 [cols="1,1,1,1,2", options="header"]
+.Table {feelpp} Debian distributions
 |===
 |Distribution | Release | Version | Supported Channels | Comment
 |debian | bookworm | 12 | latest | LTS
@@ -120,14 +125,13 @@ include::partial$install-deb.adoc[]
 // see xref:compile.adoc[how to build {feelpp} from sources].
 //
 // --
-
 Windows 10::
 +
 --
 To use {feelpp} on Windows 10, follow these steps:
 
- * [x] install  [WSL (Windows Subsystem for Linux)]
- * [x] install https://docs.microsoft.com/en-us/windows/wsl/install-manual#downloading-distributions[Ubuntu jammy (22.04) Ubuntu focal (20.04) or Debian bookworm (12)]
+ * [x] install https://docs.microsoft.com/fr-fr/windows/wsl/install-win10[WSL (Windows Subsystem for Linux)]
+ * [x] install https://docs.microsoft.com/en-us/windows/wsl/install-manual#downloading-distributions[Ubuntu jammy(22.04) Ubuntu focal (20.04) or Debian bookworm(12)]
  * [x] follow the corresponding Ubuntu or Debian {feelpp} installation steps
 
 include::partial$install-deb.adoc[]

--- a/docs/user/modules/install/pages/index.adoc
+++ b/docs/user/modules/install/pages/index.adoc
@@ -1,7 +1,6 @@
 :feelpp: Feel++
 = Get {feelpp}
 
-
 {feelpp} can be installed on Windows 10, Debian/Ubuntu systems.
 
 The main channel is called `latest`.
@@ -26,7 +25,7 @@ sudo apt update
 Ubuntu::
 +
 --
-Ubuntu LTS distributions jammy(22.04-preferred) is supported.
+Ubuntu LTS distributions jammy (22.04-preferred) is supported.
 
 We may support short term distributions.
 
@@ -48,22 +47,19 @@ par::[ubuntu,jammy,latest]
 
 par::[ubuntu,focal,latest]
 
-
 The supported systems are described below
 [cols="1,1,1,1,2", options="header"]
 .Table {feelpp} Ubuntu distributions
 |===
 |Distribution | Release | Version | Supported Channels | Comment
-
 |ubuntu | noble | 24.04 | latest | LTS
 |ubuntu | jammy | 22.04 | latest | LTS
 |ubuntu | focal | 20.04 | latest | LTS
-
-
 |===
 
 include::partial$install-deb.adoc[]
 --
+
 Debian::
 +
 --
@@ -73,14 +69,11 @@ Debian LTS distribution bookworm(12) is supported.
 
 The supported systems are described below
 [cols="1,1,1,1,2", options="header"]
-.Table {feelpp} Debian distributions
 |===
 |Distribution | Release | Version | Supported Channels | Comment
-
-|debian |bookworm | 12 | latest | LTS
-|debian |testing| - | latest | testing
-|debian |sid| - | latest | unstable
-
+|debian | bookworm | 12 | latest | LTS
+|debian | testing | - | latest | testing
+|debian | sid | - | latest | unstable
 |===
 
 [discrete]
@@ -103,41 +96,43 @@ par::[debian,testing,latest]
 
 par::[debian,sid,latest]
 
-
 include::partial$install-deb.adoc[]
 --
+
 // Fedora::
 // +
 // --
-// 
-// {feelpp} is not yet packaged for Fedora. 
-// However 
-//  
+//
+// {feelpp} is not yet packaged for Fedora.
+// However
+//
 // - [x] it is possible to compile it from source for Fedora:36 and Fedora:37
 // - [x] a docker image containing {feelpp} development environment is available for both systems
-// 
-// .Fedora 36(stable) 
-//  $ docker run --rm -it ghcr.io/feelpp/feelpp-env:fedora-36 
-// 
-// or 
-// 
+//
+// .Fedora 36(stable)
+//  $ docker run --rm -it ghcr.io/feelpp/feelpp-env:fedora-36
+//
+// or
+//
 // .Fedora 37(beta)
-//  $ docker run --rm -it ghcr.io/feelpp/feelpp-env:fedora-37 
-// 
+//  $ docker run --rm -it ghcr.io/feelpp/feelpp-env:fedora-37
+//
 // see xref:compile.adoc[how to build {feelpp} from sources].
-// 
+//
 // --
+
 Windows 10::
 +
 --
 To use {feelpp} on Windows 10, follow these steps:
 
- * [x] install https://docs.microsoft.com/fr-fr/windows/wsl/install-win10:[WSL (Windows Subsystem for Linux)]
- * [x] install https://docs.microsoft.com/en-us/windows/wsl/install-manual#downloading-distributions[Ubuntu jammy(22.04) Ubuntu focal (20.04) or Debian bookworm(12)]
+ * [x] install  [WSL (Windows Subsystem for Linux)]
+ * [x] install https://docs.microsoft.com/en-us/windows/wsl/install-manual#downloading-distributions[Ubuntu jammy (22.04) Ubuntu focal (20.04) or Debian bookworm (12)]
  * [x] follow the corresponding Ubuntu or Debian {feelpp} installation steps
 
 include::partial$install-deb.adoc[]
 --
+
 Spack::
 +
 --
@@ -157,7 +152,7 @@ source <path to spack>/spack/share/spack/setup-env.sh
 ----
 
 [discrete]
-=== Add {feelpp} Spack Mirror 
+=== Add {feelpp} Spack Mirror
 
 First set the {feelpp} mirror.
 
@@ -183,7 +178,7 @@ Add `spack.numpex` as a spack repository
 ----
 git clone https://github.com/numpex/spack.numpex <path to spack.numpex>/spack.numpex
 spack repo add <path to spack.numpex>/spack.numpex
-# check the repo 
+# check the repo
 spack repo list
 ----
 
@@ -218,8 +213,8 @@ Try get some info about {feelpp} using the command `feelpp_info`
 ----
 feelpp_info
 ----
-
 --
+
 Docker::
 +
 --
@@ -228,27 +223,28 @@ The image is based on the LTS distribution Ubuntu Noble 24.04.
 
 To download and execute it, follow the steps described below
 
-.Download and run  the feelpp docker image: contains feelpp, feelpp-toolboxes, feelpp-mor and feelpp-python
+.Download and run the feelpp docker image: contains feelpp, feelpp-toolboxes, feelpp-mor and feelpp-python
 ----
 docker pull ghcr.io/feelpp/feelpp:noble
 docker run --rm -it -v $HOME/feel:/feel ghcr.io/feelpp/feelpp:noble
 ----
 
-.Download and run  the feelpp docker image including the development kit: contains feelpp, feelpp-toolboxes, feelpp-mor and feelpp-python
+.Download and run the feelpp docker image including the development kit: contains feelpp, feelpp-toolboxes, feelpp-mor and feelpp-python
 ----
 docker pull ghcr.io/feelpp/feelpp-dev:noble
 docker run --rm -it -v $HOME/feel:/feel ghcr.io/feelpp/feelpp-dev:noble
 ----
 
 [NOTE]
-----
+====
 These images are also available for
 
 * Ubuntu 22.04 (jammy): ghcr.io/feelpp/feelpp:jammy
 * Ubuntu 20.04 (focal): ghcr.io/feelpp/feelpp:focal
 * Debian 12 (bookworm): ghcr.io/feelpp/feelpp:bookworm
-----
+====
 --
+
 Apptainer::
 +
 --
@@ -265,21 +261,19 @@ apptainer inspect feelpp-noble.sif
 apptainer run feelpp-noble.sif feelpp_toolbox_fluid --version
 ----
 
-
 [NOTE]
-----
+====
 These images are also available for
 
 * Ubuntu 22.04 (jammy): ghcr.io/feelpp/feelpp:v0.111.0-preview.10-jammy-sif
-
-----
+====
 --
 
 // MacOSX::
 // +
 // --
-// 
-// * [x] install https://brew.sh/[Homebrew] 
+//
+// * [x] install https://brew.sh/[Homebrew]
 // * [x] install {feelpp} Homebrew tap
 // [source,bash]
 // ----
@@ -290,8 +284,6 @@ These images are also available for
 // ----
 // brew install feelpp
 // ----
-// 
+//
 // --
-
 ====
-

--- a/docs/user/modules/python/pages/pyfeelppmor/reducedbasis.adoc
+++ b/docs/user/modules/python/pages/pyfeelppmor/reducedbasis.adoc
@@ -266,7 +266,7 @@ for f in Fq_:
 print("Aq", Aq)
 print("Fq", Fq)
 ----
-====
+
 
 [%collapsible.result]
 .Results

--- a/docs/user/modules/python/pages/pyfeelpptoolboxes/cfpdes.adr.adoc
+++ b/docs/user/modules/python/pages/pyfeelpptoolboxes/cfpdes.adr.adoc
@@ -1,4 +1,4 @@
-:cfpdes: Coefficient Form PDEs 
+:cfpdes: Coefficient Form PDEs
 = The advection-diffusion-reaction equation with {cfpdes} toolbox
 :feelpp: Feel++
 :stem: latexmath

--- a/docs/user/modules/python/pages/pyfeelpptoolboxes/cfpdes.index.adoc
+++ b/docs/user/modules/python/pages/pyfeelpptoolboxes/cfpdes.index.adoc
@@ -3,10 +3,10 @@
 
 == Introduction
 
-The toolbox  solves a coefficient form partial differential equation (PDE) using the finite element method. 
-In coefficient form, the PDE is expressed as a linear combination of differential operators with coefficients that may vary spatially. 
-The PDE is discretized using a finite element method, where the solution is approximated by a linear combination of basis functions defined on a mesh. The coefficients of the differential operators are also discretized on the mesh, in time and depend on parameters. 
-The resulting system of linear equations is then solved to obtain the numerical solution. 
+The toolbox  solves a coefficient form partial differential equation (PDE) using the finite element method.
+In coefficient form, the PDE is expressed as a linear combination of differential operators with coefficients that may vary spatially.
+The PDE is discretized using a finite element method, where the solution is approximated by a linear combination of basis functions defined on a mesh. The coefficients of the differential operators are also discretized on the mesh, in time and depend on parameters.
+The resulting system of linear equations is then solved to obtain the numerical solution.
 
 
 include::toolboxes:cfpdes:partial$introduction.adoc[]

--- a/docs/user/modules/python/pages/pyfeelpptoolboxes/cfpdes.linearelasticity.adoc
+++ b/docs/user/modules/python/pages/pyfeelpptoolboxes/cfpdes.linearelasticity.adoc
@@ -1,4 +1,4 @@
-:cfpdes: Coefficient Form PDEs 
+:cfpdes: Coefficient Form PDEs
 = The linear elasticity equation with {cfpdes} toolbox
 :feelpp: Feel++
 :stem: latexmath
@@ -9,13 +9,13 @@
 
 == Introduction
 
-This notebook deals with the finite element approximation of deformable continuum mechanics problems in three space dimensions. 
-The domain stem:[\Omega \subset \mathbb{R}^3] represents a deformable medium, initially at rest and to which an external loading stem:[f: \Omega \rightarrow \mathbb{R}^3] is applied. 
-The objective is to determine the displacement field stem:[u: \Omega \rightarrow \mathbb{R}^3] induced by this loading once the medium has reached equilibrium. 
-It is assumed that the deformations are small enough to be modeled in the framework of linear elasticity. 
+This notebook deals with the finite element approximation of deformable continuum mechanics problems in three space dimensions.
+The domain stem:[\Omega \subset \mathbb{R}^3] represents a deformable medium, initially at rest and to which an external loading stem:[f: \Omega \rightarrow \mathbb{R}^3] is applied.
+The objective is to determine the displacement field stem:[u: \Omega \rightarrow \mathbb{R}^3] induced by this loading once the medium has reached equilibrium.
+It is assumed that the deformations are small enough to be modeled in the framework of linear elasticity.
 For simplicity, it is also assumed that the medium is isotropic.
 
-We note stem:[\sigma: \Omega \rightarrow \mathbb{R}^{3,3}] the stress field. 
+We note stem:[\sigma: \Omega \rightarrow \mathbb{R}^{3,3}] the stress field.
 The equilibrium condition is written as follows
 [stem]
 ++++
@@ -51,9 +51,9 @@ where stem:[\lambda] and stem:[\mu] are the Lamé coefficients and stem:[\mathca
 ++++
 ****
 
-The Lamé coefficients are phenomenological coefficients which, for thermodynamic reasons, are constrained by the relations stem:[\mu>0] and stem:[\lambda+\frac{2}{3} \mu \geq 0]. 
+The Lamé coefficients are phenomenological coefficients which, for thermodynamic reasons, are constrained by the relations stem:[\mu>0] and stem:[\lambda+\frac{2}{3} \mu \geq 0].
 
-For simplicity, we assume that stem:[\lambda \geq 0] and that the medium is homogeneous so that the coefficients stem:[\lambda] and stem:[\mu] are constants. 
+For simplicity, we assume that stem:[\lambda \geq 0] and that the medium is homogeneous so that the coefficients stem:[\lambda] and stem:[\mu] are constants.
 In some applications, it is more convenient to introduce the Young's modulus stem:[E] and the Poisson's ratio stem:[\nu] such that
 
 .Relation between Lamé coefficients and Young's modulus.
@@ -75,7 +75,7 @@ The Poisson coefficient is such that stem:[-1 \leq \nu<\frac{1}{2}]; moreover, s
 The model problem  must be completed by boundary conditions. In the following, two cases are considered.
 
 .Homogeneous Dirichlet problem
-[.def#def:dirichlet]  
+[.def#def:dirichlet]
 ****
 we impose the boundary condition
 [stem]
@@ -85,7 +85,7 @@ u=0 \quad \text { on } \partial \Omega
 ****
 
 .Pure traction problem (or Neumann problem)
-[.def#def:neumann] 
+[.def#def:neumann]
 ****
 we impose the boundary condition
 [stem]
@@ -102,7 +102,7 @@ Other boundary conditions are possible such as, for example, mixed Dirichlet-Neu
 .Weak formulation.
 [.def#eq-def-a]
 ****
-On stem:[\left[H^1(\Omega)\right\]^3 \times\left[H^1(\Omega)\right\]^3], we introduce the bilinear form 
+On stem:[\left[H^1(\Omega)\right\]^3 \times\left[H^1(\Omega)\right\]^3], we introduce the bilinear form
 [stem]
 ++++
 a(v, w)=\int_{\Omega} \sigma(v): \varepsilon(w)=\int_{\Omega} \lambda(\nabla \cdot v)(\nabla \cdot w)+\int_{\Omega} 2 \mu \varepsilon(v): \varepsilon(w).
@@ -111,9 +111,9 @@ a(v, w)=\int_{\Omega} \sigma(v): \varepsilon(w)=\int_{\Omega} \lambda(\nabla \cd
 
 NOTE: For two matrices stem:[\sigma] and stem:[\varepsilon] in stem:[\mathbb{R}^{3,3}, \sigma: \varepsilon] denotes their maximal contraction, which is equal to stem:[\sum_{i, j=1}^3 \sigma_{i j} \varepsilon_{i j}].
 
-It is clear that stem:[a \in \mathcal{L}\left(\left[H^1(\Omega)\right\]^3 \times\left[H^1(\Omega)\right\]^3 ; \mathbb{R}\right)]. 
-Moreover, the bilinear form stem:[a] is symmetric and positive. 
-On the other hand, the bilinear form stem:[a] is singular. 
+It is clear that stem:[a \in \mathcal{L}\left(\left[H^1(\Omega)\right\]^3 \times\left[H^1(\Omega)\right\]^3 ; \mathbb{R}\right)].
+Moreover, the bilinear form stem:[a] is symmetric and positive.
+On the other hand, the bilinear form stem:[a] is singular.
 Indeed, by introducing the vector space of rigid displacements
 
 [stem]
@@ -136,7 +136,7 @@ We note that a rigid displacement consists in the compound of a translation and 
 
 since the only rigid displacement that preserves the boundary is the zero displacement.
 
-=== Homogeneous Dirichlet problem. 
+=== Homogeneous Dirichlet problem.
 
 In order to write the homogeneous Dirichlet problem in weak form, we introduce the functional space
 [stem]
@@ -156,7 +156,7 @@ f_{\mathrm{D}}(w)=\int_{\Omega} f \cdot w
 We obtain the following problem:
 [stem]
 ++++
-\text { Find } u \in V_{\mathrm{D}} \text { such that } 
+\text { Find } u \in V_{\mathrm{D}} \text { such that }
 a(u, w)=f_{\mathrm{D}}(w), \quad \forall w \in V_{\mathrm{D}} .
 ++++
 ****
@@ -164,28 +164,28 @@ a(u, w)=f_{\mathrm{D}}(w), \quad \forall w \in V_{\mathrm{D}} .
 
 The well-posedness of <<eq-problem-D,the previous problem>> follows from the following inequality
 
-.Lemma First Korn inequality. 
+.Lemma First Korn inequality.
 [.lem#lem:1st-korn-ineq]
 ****
 Let stem:[\Omega] be a domain of stem:[\mathbb{R}^3]. Let stem:[\|\varepsilon(v)\|_{0, \Omega}=\left(\int_{\Omega} \varepsilon(v): \varepsilon(v)\right)^{\frac{1}{2}}]. There exists a constant stem:[\boldsymbol{\kappa}_{\Omega}] such that
-[[1st-korn-ineq]]]
+[[1st-korn-ineq]]
 [stem]
 ++++
-\forall v \in\left[H_0^1(\Omega)\right]^3, \quad \kappa_{\Omega}|v\|_{1, \Omega}.
+\forall v \in\left[H_0^1(\Omega)\right]^3, \quad \kappa_{\Omega}\|v\|_{1, \Omega} \leq \|\varepsilon(v)\|_{1, \Omega}.
 ++++
 ****
 
-The <<1st-korn-ineq,inequality>> implies the coercivity of the bilinear form stem:[a] on stem:[V_{\mathrm{D}}=\left[H_0^1(\Omega)\right\]^3] since
+The <<lem:1st-korn-ineq,inequality>> implies the coercivity of the bilinear form stem:[a] on stem:[V_{\mathrm{D}}=\left[H_0^1(\Omega)\right\]^3] since
 [stem]
 ++++
 \forall v \in\left[H_0^1(\Omega)\right]^3, \quad a(v, v) \geq 2 \mu|\varepsilon(v)\|_{0, \Omega}^2 \geq 2 \mu \kappa_{\Omega}^2|v||_{1, \Omega}^2 .
 ++++
 
-=== Pure traction problem 
+=== Pure traction problem
 
-The mathematical study of the pure traction problem requires some precautions. 
+The mathematical study of the pure traction problem requires some precautions.
 
-Indeed, we cannot look for the solution stem:[u] in stem:[\left[H^1(\Omega)\right\]^3] and ask that for any stem:[w \in\left[H^1(\Omega)\right\]^3], stem:[a(u, w)=\int_{\Omega} f \cdot w+\int_{\partial \Omega} g \cdot w] because the bilinear form stem:[a] is singular on stem:[\left[H^1(\Omega)\right\]^3]. 
+Indeed, we cannot look for the solution stem:[u] in stem:[\left[H^1(\Omega)\right\]^3] and ask that for any stem:[w \in\left[H^1(\Omega)\right\]^3], stem:[a(u, w)=\int_{\Omega} f \cdot w+\int_{\partial \Omega} g \cdot w] because the bilinear form stem:[a] is singular on stem:[\left[H^1(\Omega)\right\]^3].
 
 .Necessary condition for the existence of a solution.
 [.def#def:rigid]
@@ -197,8 +197,8 @@ A necessary condition for the existence of a solution is that
 ++++
 ****
 
-This equation expresses the fact that the resultant of all external forces and their moments are zero. 
-Moreover, the solution stem:[u], if it exists, is determined only to the nearest rigid displacement. 
+This equation expresses the fact that the resultant of all external forces and their moments are zero.
+Moreover, the solution stem:[u], if it exists, is determined only to the nearest rigid displacement.
 We therefore consider the functional space
 [stem]
 ++++
@@ -219,9 +219,9 @@ a(u, w)=f_{\mathrm{N}}(w), \quad \forall w \in V_{\mathrm{N}}
 \end{array}\right.
 ++++
 
-The well-posedness of <<pure-traction-problem-varf,this problem>> follows from the following inequality 
+The well-posedness of <<pure-traction-problem-varf,this problem>> follows from the following inequality
 
-.Lemma Second inequality of Korn. 
+.Lemma Second inequality of Korn.
 [.lem#lem:2nd-korn-ineq]
 ****
 Let stem:[\Omega] be a domain of stem:[\mathbb{R}^3]. There exists a constant stem:[\kappa_{\Omega}^{\prime}] such that
@@ -231,7 +231,7 @@ Let stem:[\Omega] be a domain of stem:[\mathbb{R}^3]. There exists a constant st
 \forall v \in\left[H^1(\Omega)\right]^3, \quad \boldsymbol{\kappa}_{\Omega}^{\prime}\|v\|_{1, \Omega} \leq \|\varepsilon(v)\|_{0, \Omega}+\|v\|_{0, \Omega}
 ++++
 ****
-We show that the <<2nd-korn-ineq,inequality>>  implies the coercivity of the bilinear form stem:[a] on stem:[V_{\mathrm{N}}].
+We show that the <<lem:2nd-korn-ineq,inequality>>  implies the coercivity of the bilinear form stem:[a] on stem:[V_{\mathrm{N}}].
 
 
 [NOTE]
@@ -251,8 +251,8 @@ We find the principle of least energy. The quadratic terms in stem:[v]  represen
 
 == Conformal approximation
 
-We consider a conformal approximation of problems by Lagrangian finite elements. 
-We suppose that stem:[\Omega] is a polyhedron of stem:[\mathbb{R}^3] and we consider a regular and conformal family of affine meshes of stem:[\Omega] that we note stem:[\left\{\mathcal{T}_h\right\}_{h>0}]. 
+We consider a conformal approximation of problems by Lagrangian finite elements.
+We suppose that stem:[\Omega] is a polyhedron of stem:[\mathbb{R}^3] and we consider a regular and conformal family of affine meshes of stem:[\Omega] that we note stem:[\left\{\mathcal{T}_h\right\}_{h>0}].
 We choose as reference finite element stem:[\left\{\widehat{K}, \widehat{P}, \widehat{Sigma}\right\}] a Lagrangian finite element of degree stem:[k \geq 1].
 
 === Homogeneous Dirichlet problem
@@ -274,10 +274,10 @@ a\left(u_h, w_h\right)=f_{\mathrm{D}}\left(w_h\right), \quad \forall w_h \in V_{
 which is clearly well-posed since stem:[a] is coercive on stem:[V_{\mathrm{D}}] and stem:[V_{\mathrm{D}h} \subset V_{\mathrm{D}}].
 
 
-.Theorem Convergence. 
+.Theorem Convergence.
 [.thm#thm:convergence]
 ****
-With the above assumptions, we suppose that the unique solution stem:[u] is in 
+With the above assumptions, we suppose that the unique solution stem:[u] is in
 stem:[\left[H^{k+1}(\Omega) \cap H_0^1(\Omega)\right\]^3]. Then, there exists a constant stem:[c] such that for all stem:[h],
 [stem]
 ++++
@@ -310,7 +310,7 @@ For the pure traction problem, one way to eliminate the arbitrary rigid displace
 This leads to the approximation space
 [stem]
 ++++
-\begin{aligned} 
+\begin{aligned}
 V_{\mathrm{N} h}=\left\{v_h \in\left[\mathcal{C}^0(\bar{\Omega})\right]^3 ;\right. & \forall K \in \mathcal{T}_h, v_h \circ T_K \in[\widehat{P}]^3 ; \\ & \left.v_h\left(a_0\right)=0 ; v_h\left(a_i\right) \cdot \tau_i=0, i \in\{1,2,3\}\right\} .
 \end{aligned}
 ++++
@@ -327,7 +327,7 @@ a\left(u_h, w_h\right)=f_{\mathrm{N}}\left(w_h\right), \quad \forall w_h \in V_{
 ++++
 Using the second Korn inequality, we show that the bilinear form stem:[a] is coercive on stem:[V_{\mathrm{N} h}] so that the <<approx-problem-N,discrete problem>>  is well posed.
 
-.Theorem Convergence. 
+.Theorem Convergence.
 [.thm#thm:convergence-N]
 ****
 With the above assumptions, we suppose that the unique solution u of <<pure-traction-problem-varf,continuous problem>> is in stem:[\left[H^{k+1}(\Omega)\right\]^3 \cap V_{\mathrm{N}}]. Then there exists a constant stem:[c] such that for all stem:[h],
@@ -364,11 +364,11 @@ We are now interested in materials whose ratio of Lamé coefficients is such tha
 
 This situation occurs when the *Poisson's ratio* is very close to stem:[\frac{1}{2}], i.e. for practically incompressible materials.
 
-For such materials, it is observed that if we use a mesh that is not fine enough, the discrete solution is polluted by spurious oscillations. This phenomenon, called **coercivity loss**. 
+For such materials, it is observed that if we use a mesh that is not fine enough, the discrete solution is polluted by spurious oscillations. This phenomenon, called **coercivity loss**.
 The ratio stem:[\frac{\lambda}{\mu}] being very large, it is not reasonable to absorb it in the generic constants stem:[c] appearing in the error estimates.
-We consider the bilinear form stem:[a] defined <<eq-def-a,above>>. 
+We consider the bilinear form stem:[a] defined <<eq-def-a,above>>.
 
-.Definition Coercivity and Continuity constants. 
+.Definition Coercivity and Continuity constants.
 [.def#def:alpha-omega]
 ****
 We pose
@@ -379,17 +379,17 @@ We pose
 & \omega_a=\sup _{v \in V} \sup _{w \in V} \frac{a(v, w)}{\|v\|_{1, \Omega}\|w\|_{1, \Omega}}
 \end{aligned}
 ++++
-where stem:[V] is the functional space on which the continuous problem is posed. 
+where stem:[V] is the functional space on which the continuous problem is posed.
 ****
 
-NOTE: Under the <<coercivity-loss,hypothesis>>, we show that the ratio stem:[\frac{\omega_a}{\alpha_a}] is of order stem:[\frac{\lambda}{\mu}]. 
+NOTE: Under the <<coercivity-loss,hypothesis>>, we show that the ratio stem:[\frac{\omega_a}{\alpha_a}] is of order stem:[\frac{\lambda}{\mu}].
 
 Using the convergence analysis presented in the previous section, we obtain the error estimate
 [stem]
 ++++
 \left\|u-u_h\right\|_{1, \Omega} \leq c \frac{\lambda}{\mu} h^k|u|_{k+1, \Omega}
 ++++
-with a constant stem:[c] independent of stem:[h] and the ratio stem:[\frac{\lambda}{\mu}]. This estimate shows that the mesh must be fine enough for the error to be controlled. 
+with a constant stem:[c] independent of stem:[h] and the ratio stem:[\frac{\lambda}{\mu}]. This estimate shows that the mesh must be fine enough for the error to be controlled.
 
 === Example of coercivity loss
 

--- a/docs/user/modules/python/pages/pyfeelpptoolboxes/cfpdes.poisson.adoc
+++ b/docs/user/modules/python/pages/pyfeelpptoolboxes/cfpdes.poisson.adoc
@@ -227,9 +227,9 @@ from feelpp.toolboxes.cfpdes import *
 import pandas as pd
 
 sys.argv = ["feelpp_cfpdes_poisson"]
-e = feelpp.Environment(sys.argv,
-                        opts=tb.toolboxes_options("coefficient-form-pdes", "cfpdes"),
-                        config=feelpp.globalRepository("cfpdes-poisson-homogeneous-dirichlet"))
+e = fppc.Environment(sys.argv,
+                     opts = tb.toolboxes_options("coefficient-form-pdes", "cfpdes"),
+                     config=  fppc.globalRepository("cfpdes-poisson-homogeneous-dirichlet"))
 ----
 
 Then we consider the stem:[\mathbb{R}^2] domain stem:[\Omega] defined by stem:[\Omega=\left\{x \in \mathbb{R}^2; 0 \leq x_1 \leq 1, 0 \leq x_2 \leq 1\right\}].
@@ -238,7 +238,7 @@ We consider the following mesh stem:[\mathcal{T}_h] of stem:[\Omega] with stem:[
 [[code:2]]
 [%dynamic,python]
 ----
-def generateGeometry(filename,dim=2,hsize=0.1):
+def generateGeometry(filename, dim=2, hsize=0.1):
     """create gmsh mesh
 
     Args:
@@ -246,19 +246,19 @@ def generateGeometry(filename,dim=2,hsize=0.1):
         dim (int): dimension of the mesh
         hsize (float): mesh size
     """
-    geo="""SetFactory("OpenCASCADE");
-    h={};
-    dim={};
+    geo = """SetFactory("OpenCASCADE");
+    h = {};
+    dim = {};
     """.format(hsize,dim)
-    if dim==2 :
-        geo+="""
+    if dim == 2 :
+        geo += """
         Rectangle(1) = {0, 0, 0, 1, 1, 0};
         Characteristic Length{ PointsOf{ Surface{1}; } } = h;
         Physical Curve("Gamma_D") = {1,2,3,4};
         Physical Surface("Omega") = {1};
         """
     elif dim==3 :
-        geo+="""
+        geo += """
         Box(1) = {0, 0, 0, 1, 1, 1};
         Characteristic Length{ PointsOf{ Volume{1}; } } = h;
         Physical Surface("Gamma_D") = {1,2,3,4,5,6};
@@ -268,7 +268,7 @@ def generateGeometry(filename,dim=2,hsize=0.1):
         # Write the string to the file
         f.write(geo)
 
-def getMesh(filename,hsize=0.05,dim=2,verbose=False):
+def getMesh(filename, hsize=0.05, dim=2, verbose=False):
     """create mesh
 
     Args:
@@ -279,14 +279,14 @@ def getMesh(filename,hsize=0.05,dim=2,verbose=False):
     """
     import os
     for ext in [".msh",".geo"]:
-        f=os.path.splitext(filename)[0]+ext
+        f = os.path.splitext(filename)[0]+  ext
         # print(f)
         if os.path.exists(f):
             os.remove(f)
     if verbose:
         print(f"generate mesh {filename} with hsize={hsize} and dimension={dim}")
     generateGeometry(filename=filename,dim=dim,hsize=hsize)
-    mesh = feelpp.load(feelpp.mesh(dim=dim,realdim=dim), filename, hsize)
+    mesh = fppc.load(fppc.mesh(dim=dim,realdim=dim), filename, hsize)
     return mesh
 
 # generate 2D abd 3D meshes
@@ -307,11 +307,11 @@ The {cfpdes} toolbox allows to solve the problem <<laplace-varf,problem>> with t
 [[code:3]]
 [%dynamic,python]
 ----
-def laplacian(hsize, json, dim=2,verbose=False):
+def laplacian(hsize, json, dim=2, verbose=False):
     if verbose:
         print(f"Solving the laplacian problem for hsize = {hsize}...")
     laplacian = cfpdes(dim=dim, keyword=f"cfpdes-{dim}d")
-    laplacian.setMesh(getMesh(f"omega-{dim}.geo",hsize=hsize,dim=dim,verbose=verbose))
+    laplacian.setMesh(getMesh(f"omega-{dim}.geo", hsize=hsize, dim=dim, verbose=verbose))
     laplacian.setModelProperties(json)
     laplacian.init(buildModelAlgebraicFactory=True)
     laplacian.printAndSaveInfo()
@@ -339,7 +339,6 @@ laplacian_json = lambda order,dim=2,name="u":  {
                 },
                 "coefficients":{
                     "c":"1",
-
                     "f":"8*pi*pi*sin(2*pi*x)*sin(2*pi*y):x:y" if dim==2 else "12*pi*pi*sin(2*pi*x)*sin(2*pi*y)*sin(2*pi*z):x:y:z"
                 }
             }
@@ -373,7 +372,8 @@ laplacian_json = lambda order,dim=2,name="u":  {
             "Exports":
             {
                 "fields":["all"],
-                "expr":{
+                "expr":
+                {
                     "u_exact":"sin(2*pi*x)*sin(2*pi*y):x:y" if dim==2 else "sin(2*pi*x)*sin(2*pi*y)*sin(2*pi*z):x:y:z",
                     "grad_u_exact": "{2*pi*cos(2*pi*x)*sin(2*pi*y),2*pi*sin(2*pi*x)*cos(2*pi*y)}:x:y" if dim==2 else "{2*pi*cos(2*pi*x)*sin(2*pi*y)*sin(2*pi*z),2*pi*sin(2*pi*x)*cos(2*pi*y)*sin(2*pi*z),2*pi*sin(2*pi*x)*sin(2*pi*y)*cos(2*pi*z)}:x:y:z"
                 }
@@ -403,9 +403,9 @@ for dim in [2,3]:
         import json
         f.write(json.dumps(laplacian_json(dim=dim,order=1),indent=1))
         # execute the laplacian problem using P1 basis on a mesh of the unit square  of size 0.1
-        laplacian(hsize=0.1,json=laplacian_json(order=1,dim=dim), dim=dim,verbose=True)
+        laplacian(hsize=0.1, json=laplacian_json(order=1, dim=dim), dim=dim, verbose=True)
 # execute the laplacian problem using P2 basis on a mesh of the unit square of size 0.1
-#laplacian(hsize=0.025,json=laplacian_json(dim=2,order=2),dim=2,verbose=True)
+#laplacian(hsize=0.025, json=laplacian_json(dim=2, order=2), dim=2, verbose=True)
 ----
 
 We can proceed with the visualisation of the field `u` using the following code using `pyvista`:
@@ -441,10 +441,10 @@ def myplots(dim=2, field="cfpdes.laplace.u", factor=1, cmap='viridis'):
         warped = mesh[0].warp_by_scalar(field, factor=factor)
         warped.plot(cmap=cmap, show_scalar_bar=False, show_edges=True)
     else:
-        slices = mesh.slice_orthogonal(x=0.2,y=0.4,z=.6)
+        slices = mesh.slice_orthogonal(x=0.2, y=0.4, z=.6)
         slices.plot()
 
-myplots(dim=2,factor=0.5)
+myplots(dim=2, factor=0.5)
 ----
 <1> The `xvfbwrapper` package is used to run the `pyvista` visualisation in a virtual display. This is necessary when running the code on a remote server.
 <2> The `pyvista` package is used to visualise the mesh and the field `u`.
@@ -474,32 +474,32 @@ Then we can run the following code to:
 import pandas as pd
 import numpy as np
 
-def runLaplacianPk(df,model,verbose=False):
+def runLaplacianPk(df, model, verbose=False):
     """generate the Pk case
 
     Args:
         order (int, optional): order of the basis. Defaults to 1.
     """
-    meas=dict()
-    dim,order,json=model
+    meas = dict()
+    dim, order, json = model
     for h in df['h']:
-        m=laplacian(hsize=h,json=json,dim=dim,verbose=verbose)
+        m = laplacian(hsize=h, json=json, dim=dim, verbose=verbose)
         for norm in ['L2','H1']:
             meas.setdefault(f'P{order}-Norm_laplace_{norm}-error', [])
             meas[f'P{order}-Norm_laplace_{norm}-error'].append(m.pop(f'Norm_laplace_{norm}-error'))
-    df=df.assign(**meas)
+    df = df.assign(**meas)
     for norm in ['L2','H1']:
-        df[f'P{order}-laplace_{norm}-convergence-rate']=np.log2(df[f'P{order}-Norm_laplace_{norm}-error'].shift() / df[f'P{order}-Norm_laplace_{norm}-error']) / np.log2(df['h'].shift() / df['h'])
+        df[f'P{order}-laplace_{norm}-convergence-rate'] = np.log2(df[f'P{order}-Norm_laplace_{norm}-error'].shift() / df[f'P{order}-Norm_laplace_{norm}-error']) / np.log2(df['h'].shift() / df['h'])
     return df
 
-def runConvergenceAnalysis(json,dim=2,hs=[0.1,0.05,0.025,0.0125],orders=[1,2],verbose=False):
-    df=pd.DataFrame({'h':hs})
+def runConvergenceAnalysis(json, dim=2, hs=[0.1,0.05,0.025,0.0125], orders=[1,2], verbose=False):
+    df = pd.DataFrame({'h':hs})
     for order in orders:
-        df=runLaplacianPk(df=df,model=[dim,order,json(dim=dim,order=order)],verbose=verbose)
+        df = runLaplacianPk(df=df, model=[dim,order,json(dim=dim,order=order)], verbose=verbose)
     print(df.to_markdown()) # <1>
     return df
 
-df=runConvergenceAnalysis(json=laplacian_json,dim=2,verbose=True)
+df = runConvergenceAnalysis(json=laplacian_json,dim=2,verbose=True)
 ----
 <1> The `to_markdown` function is used to display the results in a table.
 
@@ -509,7 +509,7 @@ However we do this for different mesh sizes and only in stem:[\mathbb{P}^1] to r
 [[code:4]]
 [%dynamic,python]
 ----
-df3d=runConvergenceAnalysis(json=laplacian_json,dim=3,hs=[0.1,0.05,0.03],orders=[1],verbose=True)
+df3d = runConvergenceAnalysis(json=laplacian_json, dim=3, hs=[0.1,0.05,0.03], orders=[1], verbose=True)
 ----
 
 Again, we observe that the proper convergence rates are obtained.
@@ -530,7 +530,7 @@ from plotly.subplots import make_subplots
 import itertools
 
 def plot_convergence(df,dim,orders=[1,2]):
-    fig=px.line(df, x="h", y=[f'P{order}-Norm_laplace_{norm}-error' for order,norm in list(itertools.product(orders,['L2','H1']))])
+    fig = px.line(df, x="h", y=[f'P{order}-Norm_laplace_{norm}-error' for order,norm in list(itertools.product(orders,['L2','H1']))])
     fig.update_xaxes(title_text="h",type="log")
     fig.update_yaxes(title_text="Error",type="log")
     for order,norm in list(itertools.product(orders,['L2','H1'])):
@@ -551,7 +551,7 @@ and now we plot the convergence rates in stem:[L^2] and stem:[H^1] norms for the
 [[code:5]]
 [%dynamic%raw,python]
 ----
-fig=plot_convergence(df3d,dim=3,orders=[1])
+fig = plot_convergence(df3d, dim=3, orders=[1])
 fig.show()
 ----
 
@@ -601,7 +601,7 @@ By the Lax-Milgram lemma, this problem is well posed.
 We are interested in a conformal approximation of <<laplace-dir,the problem>> by Lagrange finite elements.
 We use the discrete framework described previously.
 We suppose that the data stem:[g] is regular enough to admit a lifting stem:[u_g] in stem:[\mathcal{C}^0(\bar{\Omega}) \cap H^1(\Omega)].
-We denote stem:[\mathcal{I}_h^{\mathrm{Lag}}] the interpolation operator associated with the mesh stem:[\mathcal{T}_h] and the finite Lagrangian element of reference stem:[\widehat{K}, \widehat{P}, \widehat{\Sigma}}].
+We denote stem:[\mathcal{I}_h^{\mathrm{Lag}}] the interpolation operator associated with the mesh stem:[\mathcal{T}_h] and the finite Lagrangian element of reference stem:[\widehat{K}], stem:[\widehat{P}], stem:[\widehat{\Sigma}].
 Recall that stem:[P_{\mathrm{c}, h}^k] denotes the stem:[H^1]-conformal space based on this finite element and that stem:[V_h] is the stem:[H_0^1]-conformal approximation space defined in (5.9).
 
 Let stem:[N=\operatorname{dim} P_{\mathrm{c}, h}^k] be given.
@@ -684,8 +684,8 @@ the boundary condition stem:[g=0] is replace by stem:[h=u] on stem:[\partial \Om
 [%dynamic, python]
 ----
 # get the laplacian json model
-def laplacian_g_json(dim,order=1):
-    j=laplacian_json(dim=dim,order=order)
+def laplacian_g_json(dim, order=1):
+    j = laplacian_json(dim=dim, order=order)
     if dim == 2:
         j['Models']['laplace']['setup']['coefficients']['f']=f'8*(pi^2)*sin(2*pi*x)*cos(2*pi*y):x:y'
         j['BoundaryConditions']['laplace']['Dirichlet']['g']={
@@ -705,10 +705,10 @@ def laplacian_g_json(dim,order=1):
     return j
 
 # in 2D
-laplacian(hsize=0.1,json=laplacian_g_json(dim=2,order=1),dim=2)
+laplacian(hsize=0.1, json=laplacian_g_json(dim=2,order=1), dim=2)
 
 # in 3D
-laplacian(hsize=0.1,json=laplacian_g_json(dim=3,order=1),dim=3)
+laplacian(hsize=0.1, json=laplacian_g_json(dim=3,order=1), dim=3)
 ----
 
 We can then plot the 2D results
@@ -732,7 +732,7 @@ We now run the convergence analysis and verify the convergence rate expected fro
 [%dynamic,python]
 ----
 # run the 2D convergence analysis
-df=runConvergenceAnalysis(json=laplacian_g_json,dim=2,verbose=True)
+df = runConvergenceAnalysis(json=laplacian_g_json, dim=2, verbose=True)
 ----
 
 We now run the convergence analysis and verify the convergence rate expected from <<thm:1>> in 2D.
@@ -740,7 +740,7 @@ We now run the convergence analysis and verify the convergence rate expected fro
 [%dynamic,python]
 ----
 # run the 2D convergence analysis
-df3d=runConvergenceAnalysis(json=laplacian_g_json,dim=3,hs=[0.1,0.05,0.03], orders=[1], verbose=True)
+df3d = runConvergenceAnalysis(json=laplacian_g_json, dim=3, hs=[0.1,0.05,0.03], orders=[1], verbose=True)
 ----
 
 
@@ -926,7 +926,7 @@ An alternative way to obtain the solution of <<laplace-N-0-approx-sys,linear sys
 
 ==== Example
 
-Consider the <<laplace-N-0,problem>> with stem:[\Omega=\mathbb{R}^2] and the exact solution stem:[u(x, y)=\sin(2*\pi*x) \sin(2*\pi*y)] in 2D and stem:[u(x, y, z)=\sin(2*\pi*x) \sin(2*\pi*y) \sin(2*\pi*z)] in 3D.
+Consider the <<laplace-N-0,problem>> with stem:[\Omega=\mathbb{R}^2] and the exact solution stem:[u(x, y)=\sin(2\pi x) \sin(2\pi y)] in 2D and stem:[u(x, y, z)=\sin(2 \pi x) \sin(2 \pi y) \sin(2\pi z)] in 3D.
 
 The right hand side stem:[f] and the boundary condition stem:[g_{\mathrm{N}}] are computed using the exact solution stem:[u] in stem:[\mathbb{R}^d, d=2,3].
 We have
@@ -948,7 +948,7 @@ The code below computes the solution of the <<laplace-N-0,problem>> using the fi
 ----
 # get the laplacian json model
 def laplacian_gN_json(dim,order=1):
-    j=laplacian_json(dim=dim,order=order)
+    j = laplacian_json(dim=dim, order=order)
     if dim == 2:
         j['Models']['laplace']['setup']['coefficients']['f']=f'8*(pi^2)*sin(2*pi*x)*sin(2*pi*y)+sin(2*pi*x)*sin(2*pi*y):x:y'
         j['Models']['laplace']['setup']['coefficients']['a']='1' # set \lambda=1
@@ -963,7 +963,7 @@ def laplacian_gN_json(dim,order=1):
     return j
 
 # in 2D
-laplacian(hsize=0.1,json=laplacian_gN_json(dim=2,order=1),dim=2)
+laplacian(hsize=0.1, json=laplacian_gN_json(dim=2, order=1), dim=2)
 ----
 
 
@@ -972,7 +972,7 @@ We now run the convergence analysis and verify the convergence rate expected fro
 [%dynamic,python]
 ----
 # run the 2D convergence analysis
-df=runConvergenceAnalysis(json=laplacian_gN_json,dim=2,verbose=True)
+df = runConvergenceAnalysis(json=laplacian_gN_json, dim=2, verbose=True)
 ----
 
 
@@ -1016,7 +1016,7 @@ The well-posedness of <<laplace-R-weak,weak problem>> results from the coercivit
 [stem]
 ++++
 \begin{equation*}
-\forall v \in H^1(\Omega), \quad\|v\|_{0, \Omega} \leq \rho_{\Omega} \left(\|nabla v|_{0, \Omega}+\|v\|_{0, \partial \Omega}\right) .
+\forall v \in H^1(\Omega), \quad\|v\|_{0, \Omega} \leq \rho_{\Omega} \left(\|\nabla v|_{0, \Omega}+\|v\|_{0, \partial \Omega}\right) .
 \end{equation*}
 ++++
 Starting from the initial discrete framework, we are interested in an approximation  by Lagrange finite elements.
@@ -1026,7 +1026,7 @@ We consider the following approximated problem:
 ++++
 \begin{equation*}
 \left\{\begin{array}{l}
-\text { Find } u_h \in P_{mathrm{c}, h}^k \text { such that } \\
+\text { Find } u_h \in P_{\mathrm{c}, h}^k \text { such that } \\
 a_{\mathrm{R}}\left(u_h, w_h\right)=f_{\mathrm{N}}\left(w_h\right), \quad \forall w_h \in P_{\mathrm{c}, h}^k,
 \end{array}\right.
 \end{equation*}
@@ -1048,7 +1048,7 @@ We have
 \begin{equation*}
 \begin{aligned}
 f=-\Delta u &=2 d \pi^2 sin(2\pi x)sin(2\pi y), \\
-\nabla u = { 2\pi cos(2\pi x)sin(2\pi y), 2\pi sin(2\pi x)sin(2\pi y) } \\
+\nabla u = \left[ 2\pi cos(2\pi x)sin(2\pi y), 2\pi sin(2\pi x)sin(2\pi y) \right] \\
 g_R &= +\gamma_R u+\nabla u \cdot n = \gamma_R sin(2\pi x)sin(2\pi y)+2\pi \cos(2\pi x)\sin(2\pi y) n_x +2\pi \sin(2\pi x) \cos(2\pi y) n_y.
 \end{aligned}
 \end{equation*}
@@ -1059,8 +1059,8 @@ The json specifications now read as follows:
 [%dynamic,python]
 ----
 # get the laplacian json model
-def laplacian_gR_json(dim,order=1):
-    j=laplacian_json(dim=dim,order=order)
+def laplacian_gR_json(dim, order=1):
+    j = laplacian_json(dim=dim, order=order)
     if dim == 2:
         j['Parameters'] = { 'gammaR': 1.0 }
         j['BoundaryConditions']['laplace'].pop('Dirichlet')
@@ -1073,7 +1073,7 @@ def laplacian_gR_json(dim,order=1):
     return j
 
 # in 2D
-laplacian(hsize=0.1,json=laplacian_gR_json(dim=2,order=1),dim=2)
+laplacian(hsize=0.1, json=laplacian_gR_json(dim=2, order=1), dim=2)
 ----
 
 We can now verify the convergence properties
@@ -1081,13 +1081,13 @@ We can now verify the convergence properties
 [%dynamic,python]
 ----
 # run the 2D convergence analysis
-df=runConvergenceAnalysis(json=laplacian_gR_json,dim=2,verbose=True)
+df=runConvergenceAnalysis(json=laplacian_gR_json, dim=2, verbose=True)
 ----
 
 === Advection-Diffusion-Reaction Equation
 
 Consider a differential operator of the form
-[[laplace-ADR-op]]]
+[[laplace-ADR-op]]
 [stem]
 ++++
 \begin{equation*}
@@ -1148,7 +1148,7 @@ a_{\sigma \beta \mu}(v, w)=\int_{\Omega} \nabla w \cdot \sigma \cdot \nabla v+w(
 ++++
 We pose stem:[p=\inf {\operatorname{ess}}{ }_{x \in \Omega}\left(\mu-\frac{1}{2} \nabla \cdot \beta\right)] and we recall that stem:[\ell_{\Omega}] is the constant intervening in the Poincaré inequality above.
 
-NOTE: For a function stem:[f \in L^{\infty}(\Omega), \inf \operatorname{ess}_{x \in \Omega} f(x)=\sup \left\{ M \in \mathbb{R}_{+}; f(x) \geq M \text{ almost\ everywhere\ in\ } \Omega\right\}].
+NOTE: For a function stem:[f \in L^{\infty}(\Omega), \inf \operatorname{ess}_{x \in \Omega} f(x)=\sup \left\{ M \in \mathbb{R}_{+}; f(x) \geq M \text{ almost everywhere in } \Omega\right\}].
 
 Then, we show that under the condition
 [[laplace-ADR-condition]]
@@ -1173,24 +1173,24 @@ The json specifications now read as follows:
 [%dynamic,python]
 ----
 # get the laplacian json model
-def adr_json(dim,order=1,c=1):
-    j=laplacian_json(dim=dim,order=order,name="u")
+def adr_json(dim, order=1, c=1):
+    j = laplacian_json(dim=dim, order=order, name="u")
     if dim == 2:
         j['Models']['laplace']['setup']['coefficients']['f']='physics_laplace_laplace_c*8*(pi^2)*sin(2*pi*x)*sin(2*pi*y)+physics_laplace_laplace_beta_0*2*pi*cos(2*pi*x)*sin(2*pi*y)+physics_laplace_laplace_beta_1*2*pi*sin(2*pi*x)*cos(2*pi*y)+physics_laplace_laplace_a*sin(2*pi*x)*sin(2*pi*y):x:y:physics_laplace_laplace_beta_0:physics_laplace_laplace_beta_1:physics_laplace_laplace_c:physics_laplace_laplace_a'
         j['Models']['laplace']['setup']['coefficients']['beta']='{1,1}'
         j['Models']['laplace']['setup']['coefficients']['a']='1'
         j['Models']['laplace']['setup']['coefficients']['c']=c
     return j
-print(adr_json(dim=2,order=1,c=1e-7))
+print(adr_json(dim=2, order=1, c=1e-7))
 # in 2D
-laplacian(hsize=0.1,json=adr_json(dim=2,order=1,c=1),dim=2)
+laplacian(hsize=0.1, json=adr_json(dim=2, order=1, c=1), dim=2)
 ----
 
 We can plot the solution:
 
 [%dynamic,python]
 ----
-myplots(dim=2,field="cfpdes.laplace.u")
+myplots(dim=2, field="cfpdes.laplace.u")
 ----
 
 and obtain the convergence rates as follows:
@@ -1198,7 +1198,7 @@ and obtain the convergence rates as follows:
 [%dynamic,python]
 ----
 # run the 2D convergence analysis with c=1
-df=runConvergenceAnalysis(json=lambda dim,order: adr_json(dim=dim,order=order,c=1),dim=2,verbose=True)
+df = runConvergenceAnalysis(json=lambda dim, order: adr_json(dim=dim,order=order,c=1), dim=2, verbose=True)
 ----
 
 [appendix]

--- a/docs/user/modules/python/pages/pyfeelpptoolboxes/index.adoc
+++ b/docs/user/modules/python/pages/pyfeelpptoolboxes/index.adoc
@@ -9,7 +9,7 @@
 {feelpp} toolboxes are availabe as python modules. The following toolboxes are available:
 
 |===
-|*Toolbox* |*Python Module* 
+|*Toolbox* |*Python Module*
 |coefficient form |feelpp.toolboxes.cfpdes
 |fluid mechanics|feelpp.toolboxes.fluid
 |heat transfert |feelpp.toolboxes.heat
@@ -32,7 +32,7 @@ import feelpp.core as fppc
 from feelpp.toolboxes.core import *
 from feelpp.toolboxes.heat import *
 
-app = feelpp.Environment(["myapp"], opts= toolboxes_options("heat"),config=feelpp.localRepository("")) # <1>
+app = fppc.Environment(["myapp"], opts=toolboxes_options("heat"), config=fppc.localRepository("")) # <1>
 ----
 <1> The first argument is the name of the application, the second argument is the directory below `feelppdb` that will be created in the current directory. The directory will contain the results of the simulation.
 
@@ -40,13 +40,15 @@ app = feelpp.Environment(["myapp"], opts= toolboxes_options("heat"),config=feelp
 Then we continue with the definition of the model and the heat toolbox.
 [source,python]
 ----
-case=feelpp.download( "github:{repo:feelpp,path:toolboxes/heat/cases/Building/ThermalBridgesENISO10211/", worldComm=app.worldCommPtr() )[0] # <1>
-casedfile=case+'/case2.cfg' 
-feelpp.Environment.setConfigFile(casefile) # <2>
+path = "toolboxes/heat/cases/Building/ThermalBridgesENISO10211"
+casefile = fppc.download( f"github:{{repo:feelpp,path:{path}/case2.cfg}}", worldComm=fppc.Environment.worldCommPtr() )[0] # <1>
+jsonfile = fppc.download( f"github:{{repo:feelpp,path:{path}/case2.json}}", worldComm=fppc.Environment.worldCommPtr() )[0]
+geofile = fppc.download( f"github:{{repo:feelpp,path:{path}/case2.geo}}", worldComm=fppc.Environment.worldCommPtr() )[0]
+fppc.Environment.setConfigFile(casefile) # <2>
 f = heat(dim=2, order=1) # <3>
 if not f.isStationary(): # <4>
     f.setTimeFinal(10*f.timeStep())
-[ok,meas]=simulate(f) # <5>
+[ok,meas] = simulate(f) # <5>
 f.checkResults() # <6>
 ----
 <1> Download the case from the feelpp repository
@@ -135,37 +137,37 @@ else:
 ====
 ----
    Normal_Heat_Flux_bottom  Points_pointA_field_temperature  \
-0                 9.317351                         7.067795   
+0                 9.317351                         7.067795
 
    Points_pointB_field_temperature  Points_pointC_field_temperature  \
-0                         0.761281                         7.900707   
+0                         0.761281                         7.900707
 
    Points_pointD_field_temperature  Points_pointE_field_temperature  \
-0                         6.278234                         0.827485   
+0                         6.278234                         0.827485
 
    Points_pointF_field_temperature  Points_pointG_field_temperature  \
-0                        16.408094                        16.334492   
+0                        16.408094                        16.334492
 
    Points_pointH_field_temperature  Points_pointI_field_temperature  \
-0                        16.766039                        18.333379   
+0                        16.766039                        18.333379
 
    Statistics_CheckGeneric_Heat-Flux_bottom_integrate  \
-0                                            0.17758    
+0                                            0.17758
 
    Statistics_CheckGeneric_Heat-Flux_top_integrate  \
-0                                         0.002046   
+0                                         0.002046
 
    Statistics_Check_Heat-Flux_bottom_integrate  \
-0                                      0.17758   
+0                                      0.17758
 
    Statistics_Check_Heat-Flux_top_integrate  \
-0                                  0.002046   
+0                                  0.002046
 
    Statistics_Inward-Heat-Flux_V2_bottom_integrate  \
-0                                         9.317351   
+0                                         9.317351
 
-   Statistics_Inward-Heat-Flux_bottom_integrate  
-0                                      9.494932  
+   Statistics_Inward-Heat-Flux_bottom_integrate
+0                                      9.494932
 ----
 ====
 


### PR DESCRIPTION
There were some typos in some pages, especially the Python ones.

Note that during the compilation of the site, many errors are still present (see, for instance, [the log](https://github.com/feelpp/book.feelpp.org/actions/runs/15928755748/job/44932424756#step:6:112) of the CI). I tried to fix some of them, such as invalid references, but I'm not well-versed in how Antora works to understand them all...
